### PR TITLE
Expose the type of signal numbers as SigNo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
+# Upcoming (unreleased) changes
+
+* Exposed a new `SigNo` type to represent the correct integer type for
+  signal numbers.  This prevents users of this library from having to
+  directly address `libc::c_int`.
+
 # 0.1.6
 
 * The internally used ArcSwap thing doesn't block other ArcSwaps now (has
   independent generation lock).
+
 # 0.1.5
 
 * Re-exported signal constants, so users no longer need libc.

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -135,12 +135,10 @@ use std::io::Error;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use libc::c_int;
-
-use SigId;
+use {SigId, SigNo};
 
 /// Registers an action to set the flag to `true` whenever the given signal arrives.
-pub fn register(signal: c_int, flag: Arc<AtomicBool>) -> Result<SigId, Error> {
+pub fn register(signal: SigNo, flag: Arc<AtomicBool>) -> Result<SigId, Error> {
     // We use SeqCst for two reasons:
     // * Signals should not come very often, so the performance does not really matter.
     // * We promise the order of actions, but setting different atomics with Relaxed or similar
@@ -149,7 +147,7 @@ pub fn register(signal: c_int, flag: Arc<AtomicBool>) -> Result<SigId, Error> {
 }
 
 /// Registers an action to set the flag to the given value whenever the signal arrives.
-pub fn register_usize(signal: c_int, flag: Arc<AtomicUsize>, value: usize) -> Result<SigId, Error> {
+pub fn register_usize(signal: SigNo, flag: Arc<AtomicUsize>, value: usize) -> Result<SigId, Error> {
     unsafe { ::register(signal, move || flag.store(value, Ordering::SeqCst)) }
 }
 

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -77,9 +77,9 @@
 use std::io::Error;
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use libc::{self, c_int};
+use libc;
 
-use SigId;
+use {SigId, SigNo};
 
 pub(crate) fn wake(pipe: RawFd) {
     unsafe {
@@ -101,7 +101,7 @@ pub(crate) fn wake(pipe: RawFd) {
 ///
 /// In this case, the pipe is taken as the `RawFd`. It is still the caller's responsibility to
 /// close it.
-pub fn register_raw(signal: c_int, pipe: RawFd) -> Result<SigId, Error> {
+pub fn register_raw(signal: SigNo, pipe: RawFd) -> Result<SigId, Error> {
     unsafe { ::register(signal, move || wake(pipe)) }
 }
 
@@ -111,7 +111,7 @@ pub fn register_raw(signal: c_int, pipe: RawFd) -> Result<SigId, Error> {
 ///
 /// Note that if you want to register the same pipe for multiple signals, there's `try_clone`
 /// method on many unix socket primitives.
-pub fn register<P>(signal: c_int, pipe: P) -> Result<SigId, Error>
+pub fn register<P>(signal: SigNo, pipe: P) -> Result<SigId, Error>
 where
     P: AsRawFd + Send + Sync + 'static,
 {

--- a/tests/tokio.rs
+++ b/tests/tokio.rs
@@ -12,7 +12,7 @@ mod tests {
     use self::tokio::prelude::*;
     use self::tokio::timer::Interval;
 
-    fn send_sig(sig: libc::c_int) {
+    fn send_sig(sig: SigNo) {
         unsafe { libc::kill(libc::getpid(), sig) };
     }
 


### PR DESCRIPTION
Before this change, users of signal-hook might have had to directly
reference libc::c_int in order to be agnostic to the size of the
integers used to represent signal numbers.  This is unfortunate.

With the advent of nix, it's reasonable for programs to stay away
from any direct use of libc -- and it'd be nice if using signal-hook
didn't require the reintroduction of a direct dependency on libc.