### PR TITLE
Turn signal numbers into an enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Upcoming (unreleased) changes
 
-* Exposed a new `SigNo` type to represent the correct integer type for
+* Exposed a new `SigNoInt` type to represent the correct integer type for
   signal numbers.  This prevents users of this library from having to
-  directly address `libc::c_int`.
+  directly address `libc::c_int` or know that they are `i32`s.
+
+* Exposed signal numbers as a `SigNo` enum with the ability to format their
+  values as user-friendly strings.  Previous implementations exposed these
+  as raw `i32`s but the internal representation of `SigNo` is the same so
+  old code should continue to compile unmodified.
 
 # 0.1.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
+# Upcoming (unreleased) changes
+
+* Exposed a new `SigNo` type to represent the correct integer type for
+  signal numbers.  This prevents users of this library from having to
+  directly address `libc::c_int`.
+
 # 0.1.6
 
 * The internally used ArcSwap thing doesn't block other ArcSwaps now (has
   independent generation lock).
+
 # 0.1.5
 
 * Re-exported signal constants, so users no longer need libc.

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -135,7 +135,7 @@ use std::io::Error;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use {SigId, SigNo};
+use {SigId, SigNo, SigNoInt};
 
 /// Registers an action to set the flag to `true` whenever the given signal arrives.
 pub fn register(signal: SigNo, flag: Arc<AtomicBool>) -> Result<SigId, Error> {
@@ -163,7 +163,7 @@ mod tests {
     fn self_signal() {
         unsafe {
             let pid = libc::getpid();
-            libc::kill(pid, ::SIGUSR1);
+            libc::kill(pid, SigNo::SIGUSR1 as SigNoInt);
         }
     }
 
@@ -185,7 +185,7 @@ mod tests {
     fn register_unregister() {
         // When we register the action, it is active.
         let flag = Arc::new(AtomicBool::new(false));
-        let signal = register(::SIGUSR1, Arc::clone(&flag)).unwrap();
+        let signal = register(SigNo::SIGUSR1, Arc::clone(&flag)).unwrap();
         self_signal();
         assert!(wait_flag(&flag));
         // But stops working after it is unregistered.

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -135,12 +135,10 @@ use std::io::Error;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use libc::c_int;
-
-use SigId;
+use {SigId, SigNo};
 
 /// Registers an action to set the flag to `true` whenever the given signal arrives.
-pub fn register(signal: c_int, flag: Arc<AtomicBool>) -> Result<SigId, Error> {
+pub fn register(signal: SigNo, flag: Arc<AtomicBool>) -> Result<SigId, Error> {
     // We use SeqCst for two reasons:
     // * Signals should not come very often, so the performance does not really matter.
     // * We promise the order of actions, but setting different atomics with Relaxed or similar
@@ -149,7 +147,7 @@ pub fn register(signal: c_int, flag: Arc<AtomicBool>) -> Result<SigId, Error> {
 }
 
 /// Registers an action to set the flag to the given value whenever the signal arrives.
-pub fn register_usize(signal: c_int, flag: Arc<AtomicUsize>, value: usize) -> Result<SigId, Error> {
+pub fn register_usize(signal: SigNo, flag: Arc<AtomicUsize>, value: usize) -> Result<SigId, Error> {
     unsafe { ::register(signal, move || flag.store(value, Ordering::SeqCst)) }
 }
 

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -77,9 +77,9 @@
 use std::io::Error;
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use libc::{self, c_int};
+use libc;
 
-use SigId;
+use {SigId, SigNo};
 
 pub(crate) fn wake(pipe: RawFd) {
     unsafe {
@@ -101,7 +101,7 @@ pub(crate) fn wake(pipe: RawFd) {
 ///
 /// In this case, the pipe is taken as the `RawFd`. It is still the caller's responsibility to
 /// close it.
-pub fn register_raw(signal: c_int, pipe: RawFd) -> Result<SigId, Error> {
+pub fn register_raw(signal: SigNo, pipe: RawFd) -> Result<SigId, Error> {
     unsafe { ::register(signal, move || wake(pipe)) }
 }
 
@@ -111,7 +111,7 @@ pub fn register_raw(signal: c_int, pipe: RawFd) -> Result<SigId, Error> {
 ///
 /// Note that if you want to register the same pipe for multiple signals, there's `try_clone`
 /// method on many unix socket primitives.
-pub fn register<P>(signal: c_int, pipe: P) -> Result<SigId, Error>
+pub fn register<P>(signal: SigNo, pipe: P) -> Result<SigId, Error>
 where
     P: AsRawFd + Send + Sync + 'static,
 {

--- a/tests/tokio.rs
+++ b/tests/tokio.rs
@@ -12,7 +12,7 @@ mod tests {
     use self::tokio::prelude::*;
     use self::tokio::timer::Interval;
 
-    fn send_sig(sig: libc::c_int) {
+    fn send_sig(sig: SigNo) {
         unsafe { libc::kill(libc::getpid(), sig) };
     }
 


### PR DESCRIPTION
This PR contains two changes: one to expose the raw integer type of the signals to avoid users having to depend on `libc::c_int`, and another change to turn the signal numbers into an enum. The latter follows the pattern of the `nix` crate for handling errnos and the new "feature" is that now signals can be formatted for printing in a nicer manner.

These two changes don't really make sense as separate commits but I'm keeping them as such for now because they are two separate ideas. If you agree to this proposal, I can fold them and adjust the description and `CHANGELOG.md` entry to make more sense as a single unit. But if you think this is a bad idea, I can drop the latter commit and return to the original PR https://github.com/vorner/signal-hook/pull/8 that only included the first commit.

Let me know! Thanks.