### PR TITLE
Windows support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rust:
     - beta
     - nightly
 os:
+    - windows
     - linux
     - osx
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,15 @@ mio = { version = "~0.6", optional = true }
 signal-hook-registry = { version = "~1", path = "signal-hook-registry" }
 tokio-reactor = { version = "~0.1", optional = true }
 
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "~0.3", features = ["consoleapi", "minwindef", "wincon"] }
+
 [dev-dependencies]
 version-sync = "~0.8"
 tokio = "~0.1"
+
+[target.'cfg(windows)'.dev-dependencies]
+winapi = { version = "~0.3", features = ["consoleapi", "minwindef", "wincon", "namedpipeapi"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/signal-hook-registry/src/lib.rs
+++ b/signal-hook-registry/src/lib.rs
@@ -4,6 +4,7 @@
 )]
 #![deny(missing_docs, warnings)]
 #![allow(unknown_lints, bare_trait_objects)]
+#![cfg(not(windows))]
 
 //! Backend of the [signal-hook] crate.
 //!

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -85,6 +85,9 @@
 //!     signal_hook::flag::register(signal_hook::SIGUSR1, Arc::clone(&got))?;
 //!     unsafe {
 //!         let pid = libc::getpid();
+//! #       #[cfg(windows)]
+//! #       signal_hook::__emulate_kill(pid, signal_hook::SIGUSR1);
+//! #       #[cfg(not(windows))]
 //!         libc::kill(pid, signal_hook::SIGUSR1);
 //!     }
 //!     // A sleep here, because it could run the signal handler in another thread and we may not
@@ -160,12 +163,17 @@ mod tests {
 
     use libc;
 
+    #[cfg(windows)]
+    use __emulate_kill as kill;
+    #[cfg(not(windows))]
+    use libc::kill;
+
     use super::*;
 
     fn self_signal() {
         unsafe {
             let pid = libc::getpid();
-            libc::kill(pid, ::SIGUSR1);
+            kill(pid, ::SIGUSR1);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,15 +128,35 @@ extern crate mio;
 extern crate signal_hook_registry;
 #[cfg(feature = "tokio-support")]
 extern crate tokio_reactor;
+#[cfg(windows)]
+extern crate winapi;
 
 pub mod flag;
 pub mod iterator;
+#[cfg(not(windows))]
 pub mod pipe;
+#[cfg(windows)]
+pub mod pipe_windows;
+#[cfg(windows)]
+mod windows;
 
+#[cfg(not(windows))]
 pub use libc::{
     SIGABRT, SIGALRM, SIGBUS, SIGCHLD, SIGCONT, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGIO, SIGKILL,
     SIGPIPE, SIGPROF, SIGQUIT, SIGSEGV, SIGSTOP, SIGSYS, SIGTERM, SIGTRAP, SIGUSR1, SIGUSR2,
     SIGWINCH,
 };
 
+#[cfg(not(windows))]
 pub use signal_hook_registry::{register, unregister, SigId, FORBIDDEN};
+
+#[cfg(windows)]
+pub use windows::{
+    register, unregister, SigId, FORBIDDEN, SIGABRT, SIGALRM, SIGBUS, SIGCHLD, SIGCONT, SIGFPE,
+    SIGHUP, SIGILL, SIGINT, SIGIO, SIGKILL, SIGPIPE, SIGPROF, SIGQUIT, SIGSEGV, SIGSTOP, SIGSYS,
+    SIGTERM, SIGTRAP, SIGUSR1, SIGUSR2, SIGWINCH,
+};
+
+#[cfg(windows)]
+#[doc(hidden)]
+pub use windows::__emulate_kill;

--- a/src/pipe_windows.rs
+++ b/src/pipe_windows.rs
@@ -1,0 +1,204 @@
+//! Module with the self-pipe pattern.
+//!
+//! One of the common patterns around signals is to have a pipe with both ends in the same program.
+//! Whenever there's a signal, the signal handler writes to the write end. The application then can
+//! handle the read end.
+//!
+//! This has two advantages. First, the real signal action moves outside of the signal handler
+//! where there are a lot less restrictions. Second, it fits nicely in all kinds of asynchronous
+//! loops and has less chance of race conditions.
+//!
+//! This module offers premade functions for the write end (and doesn't insist that it must be a
+//! pipe ‒ anything that can be `sent` to is fine ‒ sockets too, therefore `UnixStream::pair` is a
+//! good candidate).
+//!
+//! If you want to integrate with some asynchronous library, plugging streams from `mio-uds` or
+//! `tokio-uds` libraries should work.
+//!
+//! If it looks too low-level for your needs, the [`iterator`](../iterator/) module contains some
+//! higher-lever interface that also uses a self-pipe pattern under the hood.
+//!
+//! # Correct order of handling
+//!
+//! A care needs to be taken to avoid race conditions, especially when handling the same signal in
+//! a loop. Specifically, another signal might come when the action for the previous signal is
+//! being taken. The correct order is first to clear the content of the pipe (read some/all data
+//! from it) and then take the action. This way a spurious wakeup can happen (the pipe could wake
+//! up even when no signal came after the signal was taken, because ‒ it arrived between cleaning
+//! the pipe and taking the action). Note that some OS primitives (eg. `select`) suffer from
+//! spurious wakeups themselves (they can claim a FD is readable when it is not true) and blocking
+//! `read` might return prematurely (with eg. `EINTR`).
+//!
+//! The reverse order of first taking the action and then clearing the pipe might lose signals,
+//! which is usually worse.
+//!
+//! This is not a problem with blocking on reading from the pipe (because both the blocking and
+//! cleaning is the same action), but in case of asynchronous handling it matters.
+//!
+//! If you want to combine setting some flags with a self-pipe pattern, the flag needs to be set
+//! first, then the pipe written. On the read end, first the pipe needs to be cleaned, then the
+//! flag and then the action taken. This is what the [`Signals`](../iterator/struct.Signals.html)
+//! structure does internally.
+//!
+//! # Write collating
+//!
+//! While unlikely if handled correctly, it is possible the write end is full when a signal comes.
+//! In such case the signal handler simply does nothing. If the write end is full, the read end is
+//! readable and therefore will wake up. On the other hand, blocking in the signal handler would
+//! definitely be a bad idea.
+//!
+//! However, this also means the number of bytes read from the end might be lower than the number
+//! of signals that arrived. This should not generally be a problem, since the OS already collates
+//! signals of the same kind together.
+//!
+//! # Examples
+//!
+//! This example waits for at last one `SIGUSR1` signal to come before continuing (and
+//! terminating). It sends the signal to itself, so it correctly terminates.
+//!
+//! ```rust
+//! extern crate libc;
+//! extern crate winapi;
+//! extern crate signal_hook;
+//!
+//! use std::fs::File;
+//! use std::io::{Error, Read};
+//! use std::ptr;
+//! use std::os::windows::prelude::*;
+//! use winapi::um::namedpipeapi::CreatePipe;
+//! use winapi::um::winnt::HANDLE;
+//!
+//! fn main() -> Result<(), Error> {
+//!     let (mut read, write) = {
+//!         let mut read: HANDLE = ptr::null_mut();
+//!         let mut write: HANDLE = ptr::null_mut();
+//!         let success = unsafe { CreatePipe(&mut read, &mut write, ptr::null_mut(), 1024) } != 0;
+//!         assert!(success);
+//!         let read = unsafe { File::from_raw_handle(read as RawHandle) };
+//!         let write = unsafe { File::from_raw_handle(write as RawHandle) };
+//!         (read, write)
+//!     };
+//!     signal_hook::pipe_windows::register_handle(signal_hook::SIGINT, write)?;
+//! # fn do_something_that_may_be_interrupted_by_ctrl_c() {}
+//!     do_something_that_may_be_interrupted_by_ctrl_c();
+//!     let mut buff = [0];
+//! # if false {
+//!     read.read_exact(&mut buff)?;
+//! # }
+//!     println!("Happily terminating");
+//!     Ok(())
+//! }
+//! ```
+
+use std::io::Error;
+use std::os::windows::prelude::*;
+use std::ptr;
+
+use libc::c_int;
+use winapi::um::fileapi::WriteFile;
+use winapi::um::winnt::HANDLE;
+use winapi::um::winsock2::{send, SOCKET};
+
+use SigId;
+
+pub(crate) fn wake_handle(pipe: RawHandle) {
+    unsafe {
+        let mut num_written = 0;
+        let _success = WriteFile(
+            pipe as HANDLE,
+            b"X" as *const _ as *const _,
+            1,
+            &mut num_written,
+            ptr::null_mut(),
+        );
+    }
+}
+
+pub(crate) fn wake_socket(pipe: RawSocket) {
+    unsafe {
+        send(pipe as SOCKET, b"X" as *const _ as *const _, 1, 0);
+    }
+}
+
+/// Registers a write to a self-pipe whenever there's the signal.
+///
+/// In this case, the pipe is taken as the `RawHandle`. It is still the caller's responsibility to
+/// close it.
+pub fn register_handle_raw(signal: c_int, pipe: RawHandle) -> Result<SigId, Error> {
+    struct SendHandle(RawHandle);
+    unsafe impl Send for SendHandle {}
+    unsafe impl Sync for SendHandle {}
+    let pipe = SendHandle(pipe);
+    unsafe { ::register(signal, move || wake_handle(pipe.0)) }
+}
+
+/// Registers a write to a self-pipe whenever there's the signal.
+///
+/// In this case, the pipe is taken as the `RawSocket`. It is still the caller's responsibility to
+/// close it.
+pub fn register_socket_raw(signal: c_int, pipe: RawSocket) -> Result<SigId, Error> {
+    struct SendSocket(RawSocket);
+    unsafe impl Send for SendSocket {}
+    unsafe impl Sync for SendSocket {}
+    let pipe = SendSocket(pipe);
+    unsafe { ::register(signal, move || wake_socket(pipe.0)) }
+}
+
+/// Registers a write to a self-pipe whenever there's the signal.
+///
+/// The ownership of pipe is taken and will be closed whenever the created action is unregistered.
+///
+/// Note that if you want to register the same pipe for multiple signals, there's `try_clone`
+/// method on many unix socket primitives.
+pub fn register_handle<P>(signal: c_int, pipe: P) -> Result<SigId, Error>
+where
+    P: AsRawHandle + Send + Sync + 'static,
+{
+    let action = move || wake_handle(pipe.as_raw_handle());
+    unsafe { ::register(signal, action) }
+}
+
+/// Registers a write to a self-pipe whenever there's the signal.
+///
+/// The ownership of pipe is taken and will be closed whenever the created action is unregistered.
+///
+/// Note that if you want to register the same pipe for multiple signals, there's `try_clone`
+/// method on many unix socket primitives.
+pub fn register_socket<P>(signal: c_int, pipe: P) -> Result<SigId, Error>
+where
+    P: AsRawSocket + Send + Sync + 'static,
+{
+    let action = move || wake_socket(pipe.as_raw_socket());
+    unsafe { ::register(signal, action) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs::File;
+    use std::io::prelude::*;
+    use std::ptr;
+    use winapi::um::namedpipeapi::CreatePipe;
+    use winapi::um::winnt::HANDLE;
+
+    #[test]
+    fn pipe_notify() -> Result<(), ::std::io::Error> {
+        let (mut read, write) = {
+            let mut read: HANDLE = ptr::null_mut();
+            let mut write: HANDLE = ptr::null_mut();
+            let success = unsafe { CreatePipe(&mut read, &mut write, ptr::null_mut(), 1024) } != 0;
+            assert!(success);
+            let read = unsafe { File::from_raw_handle(read as RawHandle) };
+            let write = unsafe { File::from_raw_handle(write as RawHandle) };
+            (read, write)
+        };
+        register_handle(::SIGUSR1, write)?;
+        // This will write into the pipe write end through the signal handler
+        unsafe { ::__emulate_kill(libc::getpid(), ::SIGUSR1) };
+        let mut buff = [0];
+        read.read_exact(&mut buff)?;
+        println!("Happily terminating");
+        Ok(())
+    }
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, bare_trait_objects)]
+
 //! Signal emulation for Windows.
 
 use libc::c_int;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,0 +1,338 @@
+//! Signal emulation for Windows.
+
+use libc::c_int;
+use std::collections::{BTreeMap, HashMap};
+use std::io::Error;
+use std::sync::Mutex;
+use winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
+use winapi::um::consoleapi::SetConsoleCtrlHandler;
+use winapi::um::wincon::{CTRL_BREAK_EVENT, CTRL_C_EVENT};
+
+// From Windows CRT...
+// SIGINT = 2
+// SIGILL = 4
+// SIGFPE = 8
+// SIGSEGV = 11
+// SIGTERM = 15
+// SIGBREAK = 21
+// SIGABRT = 22
+pub use libc::{SIGABRT, SIGFPE, SIGILL, SIGINT, SIGSEGV, SIGTERM};
+
+const DUMMY_OFFSET: c_int = 64;
+
+// Define as Linux x86 signal number + 10000
+/// Dummy value for SIGALRM which is missing in Windows.
+pub const SIGALRM: c_int = DUMMY_OFFSET + 14;
+/// Dummy value for SIGBUS which is missing in Windows.
+pub const SIGBUS: c_int = DUMMY_OFFSET + 7;
+/// Dummy value for SIGCHLD which is missing in Windows.
+pub const SIGCHLD: c_int = DUMMY_OFFSET + 17;
+/// Dummy value for SIGCONT which is missing in Windows.
+pub const SIGCONT: c_int = DUMMY_OFFSET + 18;
+/// Dummy value for SIGHUP which is missing in Windows.
+pub const SIGHUP: c_int = DUMMY_OFFSET + 1;
+/// Dummy value for SIGIO which is missing in Windows.
+pub const SIGIO: c_int = DUMMY_OFFSET + 29;
+/// Dummy value for SIGKILL which is missing in Windows.
+pub const SIGKILL: c_int = DUMMY_OFFSET + 9;
+/// Dummy value for SIGPIPE which is missing in Windows.
+pub const SIGPIPE: c_int = DUMMY_OFFSET + 13;
+/// Dummy value for SIGPROF which is missing in Windows.
+pub const SIGPROF: c_int = DUMMY_OFFSET + 27;
+/// Dummy value for SIGQUIT which is missing in Windows.
+pub const SIGQUIT: c_int = DUMMY_OFFSET + 3;
+/// Dummy value for SIGSTOP which is missing in Windows.
+pub const SIGSTOP: c_int = DUMMY_OFFSET + 19;
+/// Dummy value for SIGSYS which is missing in Windows.
+pub const SIGSYS: c_int = DUMMY_OFFSET + 31;
+/// Dummy value for SIGTRAP which is missing in Windows.
+pub const SIGTRAP: c_int = DUMMY_OFFSET + 5;
+/// Dummy value for SIGUSR1 which is missing in Windows.
+pub const SIGUSR1: c_int = DUMMY_OFFSET + 10;
+/// Dummy value for SIGUSR2 which is missing in Windows.
+pub const SIGUSR2: c_int = DUMMY_OFFSET + 12;
+/// Dummy value for SIGWINCH which is missing in Windows.
+pub const SIGWINCH: c_int = DUMMY_OFFSET + 28;
+
+/// List of forbidden signals.
+///
+/// Some signals are impossible to replace according to POSIX and some are so special that this
+/// library refuses to handle them (eg. SIGSEGV). The routines panic in case registering one of
+/// these signals is attempted.
+///
+/// See [`register`](fn.register.html).
+pub const FORBIDDEN: &[c_int] = &[SIGKILL, SIGSTOP, SIGILL, SIGFPE, SIGSEGV];
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+struct ActionId(u64);
+
+/// An ID of registered action.
+///
+/// This is returned by all the registration routines and can be used to remove the action later on
+/// with a call to [`unregister`](fn.unregister.html).
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct SigId {
+    signal: c_int,
+    action: ActionId,
+}
+
+type Action = Fn() + Send + Sync;
+
+struct GlobalData {
+    // RCU isn't necessary here. Unlike posix signals, Windows Console handler is called in a separate thread.
+    state: Mutex<GlobalDataState>,
+}
+
+struct GlobalDataState {
+    action_id: u64,
+    all_signals: HashMap<c_int, BTreeMap<ActionId, Box<Action>>>,
+}
+
+impl GlobalData {
+    fn ensure() -> &'static Self {
+        use std::cell::UnsafeCell;
+        use std::sync::Once;
+
+        struct GlobalCell(UnsafeCell<Option<GlobalData>>);
+        unsafe impl Sync for GlobalCell {}
+        static GLOBAL: GlobalCell = GlobalCell(UnsafeCell::new(None));
+        static GLOBAL_ONCE: Once = Once::new();
+
+        GLOBAL_ONCE.call_once(|| unsafe {
+            *GLOBAL.0.get() = Some(GlobalData::new());
+        });
+
+        if let &Some(ref data) = unsafe { &*GLOBAL.0.get() } {
+            data
+        } else {
+            unreachable!();
+        }
+    }
+
+    fn new() -> Self {
+        assert!(unsafe { SetConsoleCtrlHandler(Some(handler), TRUE) != 0 });
+        GlobalData {
+            state: Mutex::new(GlobalDataState::new()),
+        }
+    }
+}
+impl GlobalDataState {
+    fn new() -> Self {
+        Self {
+            action_id: 0,
+            all_signals: HashMap::new(),
+        }
+    }
+}
+
+extern "system" fn handler(ctrl_type: DWORD) -> BOOL {
+    if let Some(signal) = to_signal(ctrl_type) {
+        let data = GlobalData::ensure();
+        let state = data.state.lock().unwrap();
+        if let Some(all_signals) = state.all_signals.get(&signal) {
+            for action in all_signals.values() {
+                action();
+            }
+
+            // returning TRUE here has two effects:
+            // 1. Default behavior is prevented.
+            // 2. Handlers registered earlier than this are not invoked.
+            //
+            // Ideally we want to prevent default behavior while keeping
+            // old callbacks, but it's impossible.
+            //
+            // And we may want to return FALSE if `all_signals` is empty.
+            // I didn't do so to align with the unix implementation.
+            return TRUE;
+        }
+    }
+    FALSE
+}
+
+fn to_signal(ctrl_type: DWORD) -> Option<c_int> {
+    if ctrl_type == CTRL_C_EVENT {
+        Some(SIGINT)
+    } else if ctrl_type == CTRL_BREAK_EVENT {
+        Some(SIGTERM)
+    } else {
+        None
+    }
+}
+
+/// Registers an arbitrary action for the given signal.
+///
+/// This makes sure there's a signal handler for the given signal. It then adds the action to the
+/// ones called each time the signal is delivered. If multiple actions are set for the same signal,
+/// all are called, in the order of registration.
+///
+/// If there was a previous signal handler for the given signal, it is chained ‒ it will be called
+/// as part of this library's signal handler, before any actions set through this function.
+///
+/// On success, the function returns an ID that can be used to remove the action again with
+/// [`unregister`](fn.unregister.html).
+///
+/// # Panics
+///
+/// If the signal is one of (see [`FORBIDDEN`]):
+///
+/// * `SIGKILL`
+/// * `SIGSTOP`
+/// * `SIGILL`
+/// * `SIGFPE`
+/// * `SIGSEGV`
+///
+/// The first two are not possible to override (and the underlying C functions simply ignore all
+/// requests to do so, which smells of possible bugs, or return errors). The rest can be set, but
+/// generally needs very special handling to do so correctly (direct manipulation of the
+/// application's address space, `longjmp` and similar). Unless you know very well what you're
+/// doing, you'll shoot yourself into the foot and this library won't help you with that.
+///
+/// # Errors
+///
+/// Since the library manipulates signals using the low-level C functions, all these can return
+/// errors. Generally, the errors mean something like the specified signal does not exist on the
+/// given platform ‒ ofter a program is debugged and tested on a given OS, it should never return
+/// an error.
+///
+/// However, if an error *is* returned, there are no guarantees if the given action was registered
+/// or not.
+///
+/// # Unsafety
+///
+/// This function is unsafe, because the `action` is run inside a signal handler. The set of
+/// functions allowed to be called from within is very limited (they are called signal-safe
+/// functions by POSIX). These specifically do *not* contain mutexes and memory
+/// allocation/deallocation. They *do* contain routines to terminate the program, to further
+/// manipulate signals (by the low-level functions, not by this library) and to read and write file
+/// descriptors. Calling program's own functions consisting only of these is OK, as is manipulating
+/// program's variables ‒ however, as the action can be called on any thread that does not have the
+/// given signal masked (by default no signal is masked on any thread), and mutexes are a no-go,
+/// this is harder than it looks like at first.
+///
+/// As panicking from within a signal handler would be a panic across FFI boundary (which is
+/// undefined behavior), the passed handler must not panic.
+///
+/// If you find these limitations hard to satisfy, choose from the helper functions in submodules
+/// of this library ‒ these provide safe interface to use some common signal handling patters.
+///
+/// # Race condition
+///
+/// Currently, there's a short race condition. If this is the first action for the given signal,
+/// there was another signal handler previously and the signal comes into a different thread during
+/// this function, it can happen the original handler is not chained in this one instance.
+///
+/// This is considered unimportant problem, since most programs install their signal handlers
+/// during startup, before the signals effectively do anything. If you want to avoid the race
+/// condition completely, initialize all signal handling before starting any threads.
+///
+/// # Performance
+///
+/// Even when it is possible to repeatedly install and remove actions during the lifetime of a
+/// program, the installation and removal is considered a slow operation and should not be done
+/// very often. Also, there's limited (though huge) amount of distinct IDs (they are `u64`).
+///
+/// # Examples
+///
+/// ```rust
+/// extern crate signal_hook;
+///
+/// use std::io::Error;
+/// use std::process;
+///
+/// fn main() -> Result<(), Error> {
+///     let signal = unsafe { signal_hook::register(signal_hook::SIGTERM, || process::abort()) }?;
+///     // Stuff here...
+///     signal_hook::unregister(signal); // Not really necessary.
+///     Ok(())
+/// }
+/// ```
+pub unsafe fn register<F>(signal: c_int, action: F) -> Result<SigId, Error>
+where
+    F: Fn() + Sync + Send + 'static,
+{
+    assert!(
+        !FORBIDDEN.contains(&signal),
+        "Attempted to register forbidden signal {}",
+        signal,
+    );
+    let data = GlobalData::ensure();
+    let mut state = data.state.lock().unwrap();
+    let action_id = ActionId(state.action_id);
+    state.action_id += 1;
+
+    let sig_id = SigId {
+        signal,
+        action: action_id,
+    };
+
+    let all_signals = state.all_signals.entry(signal).or_insert(BTreeMap::new());
+    all_signals.insert(action_id, Box::new(action));
+
+    Ok(sig_id)
+}
+
+/// Removes a previously installed action.
+///
+/// This function does nothing if the action was already removed. It returns true if it was removed
+/// and false if the action wasn't found.
+///
+/// It can unregister all the actions installed by [`register`](fn.register.html) as well as the
+/// ones from helper submodules.
+///
+/// # Warning
+///
+/// This does *not* currently return the default/previous signal handler if the last action for a
+/// signal was just unregistered. That means that if you replaced for example `SIGTERM` and then
+/// removed the action, the program will effectively ignore `SIGTERM` signals from now on, not
+/// terminate on them as is the default action. This is OK if you remove it as part of a shutdown,
+/// but it is not recommended to remove termination actions during the normal runtime of
+/// application (unless the desired effect is to create something that can be terminated only by
+/// SIGKILL).
+pub fn unregister(id: SigId) -> bool {
+    let data = GlobalData::ensure();
+    let mut state = data.state.lock().unwrap();
+    let mut replace = false;
+    if let Some(actions) = state.all_signals.get_mut(&id.signal) {
+        replace = actions.remove(&id.action).is_some();
+    }
+    replace
+}
+
+// Emulates kill(2) for testing `signal-hook` in Windows.
+#[doc(hidden)]
+pub unsafe fn __emulate_kill(pid: c_int, signal: c_int) -> c_int {
+    let self_pid = ::libc::getpid();
+    if pid != self_pid && pid != -self_pid && pid != 0 && pid != -1 {
+        return 0;
+    }
+
+    let data = GlobalData::ensure();
+    let state = data.state.lock().unwrap();
+    if let Some(all_signals) = state.all_signals.get(&signal) {
+        for action in all_signals.values() {
+            action();
+        }
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn panic_forbidden() {
+        let _ = unsafe { register(SIGKILL, || ()) };
+    }
+
+    /// Check that registration works as expected and that unregister tells if it did or not.
+    #[test]
+    fn register_unregister() {
+        let signal = unsafe { register(SIGUSR1, || ()).unwrap() };
+        // It was there now, so we can unregister
+        assert!(unregister(signal));
+        // The next time unregistering does nothing and tells us so.
+        assert!(!unregister(signal));
+    }
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -102,7 +102,7 @@ impl GlobalData {
             *GLOBAL.0.get() = Some(GlobalData::new());
         });
 
-        if let &Some(ref data) = unsafe { &*GLOBAL.0.get() } {
+        if let Some(ref data) = *unsafe { &*GLOBAL.0.get() } {
             data
         } else {
             unreachable!();
@@ -265,7 +265,10 @@ where
         action: action_id,
     };
 
-    let all_signals = state.all_signals.entry(signal).or_insert(BTreeMap::new());
+    let all_signals = state
+        .all_signals
+        .entry(signal)
+        .or_insert_with(BTreeMap::new);
     all_signals.insert(action_id, Box::new(action));
 
     Ok(sig_id)

--- a/tests/tokio.rs
+++ b/tests/tokio.rs
@@ -12,8 +12,13 @@ mod tests {
     use self::tokio::prelude::*;
     use self::tokio::timer::Interval;
 
+    #[cfg(not(windows))]
+    use self::libc::kill;
+    #[cfg(windows)]
+    use self::signal_hook::__emulate_kill as kill;
+
     fn send_sig(sig: libc::c_int) {
-        unsafe { libc::kill(libc::getpid(), sig) };
+        unsafe { kill(libc::getpid(), sig) };
     }
 
     #[test]


### PR DESCRIPTION
I've tried implementing signal-hook on Windows with almost equivalent API.

## Difference in behavior

- Only `SIGINT` and `SIGTERM` are emulated through `CTRL_C_EVENT` and `CTRL_BREAK_EVENT`.
- Not all Ctrl-C operations work. As far as I've tested in a small example, it works if the program is launched from classical terminal + cmd. It doesn't capture Ctrl-C if the program is launched from mintty + msys2.
- By `SetConsoleCtrlHandler`'s nature, the handlers are called in a separate thread.
- If other handlers are already registered, they will be skipped.

## Difference in API

- Only a part of signal constants is provided from Windows CRT. Other signal constants are manufactured by `(Number in Linux x86) + 64`.
- The emulation layer is at `signal-hook`, not `signal-hook-registry`. No `register_unchecked` provided.
- `signal_hook::pipe` depends on `std::os::unix`, which means it's inherently `#[cfg(unix)]` only. I implemented a similar module called `signal_hook::pipe_windows`.
- ~~There seems no way to generate the Ctrl-C/Ctrl-Break behavior from programs, like `libc::kill`. I exposed `signal_hook::__emulate_kill` which emulates `kill` behavior for testing.~~ <br>
  I've found [`GenerateConsoleCtrlEvent`](https://docs.microsoft.com/ja-jp/windows/console/generateconsolectrlevent) later. I'll modify this PR to use the function.

## Difference in implementation

- We don't need async-signal-safety due to `SetConsoleCtrlHandler` launching a separate thread for handlers. Therefore, in `signal_hook::iterator`, I implemented the same functionality using a usual synchronization primitives (Mutex + Condvar). There seems no handy portable equivalent of `UnixSocket`.