### PR TITLE
lib: add SIGINFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# latest
+
+* added support for `SIGINFO` on operating systems which support it.
+
 # 0.1.12
 
 * `cleanup` module to register resetting signals to default.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,10 @@ pub use libc::{
     SIGWINCH,
 };
 
+#[cfg(not(any(target_os = "linux", windows)))]
+pub use libc::SIGINFO;
+
+
 #[cfg(windows)]
 pub use libc::{SIGABRT, SIGFPE, SIGILL, SIGINT, SIGSEGV, SIGTERM};
 

--- a/tests/iterator.rs
+++ b/tests/iterator.rs
@@ -67,3 +67,10 @@ fn signals_block_wait() {
         .expect_err("Wait didn't wait properly");
     assert_eq!(err, RecvTimeoutError::Timeout);
 }
+
+#[cfg(not(any(target_os = "linux", windows)))]
+use signal_hook::SIGINFO;
+#[test]
+fn siginfo_is_valid_signal() {
+    let _signal: Signals = Signals::new(&[SIGINFO]).unwrap();
+}


### PR DESCRIPTION
modern operating systems have an additional non-POSIX signal SIGINFO.
This is typically sent to an application by pressing ctrl-t.