### PR TITLE
Fix a bug in the signals_close_forever test

### DIFF
--- a/tests/iterator.rs
+++ b/tests/iterator.rs
@@ -30,6 +30,10 @@ fn signals_close_forever() {
         })
     });
 
+    // The map method is lazy and will execute the function only during iteration. So we
+    // collect the JoinHandles to ensure the threads are actually started.
+    let threads: Vec<thread::JoinHandle<()>> = threads.collect();
+
     // Wait a bit… if some thread terminates by itself.
     thread::sleep(Duration::from_millis(100));
     assert!(!stopped.load(Ordering::SeqCst));


### PR DESCRIPTION
Hi,

I found a small bug in the signals_close_forever test. The threads spawn logic wasn't executed until the final
for loop and one thread was spawned after the other because of the join in the for loop body. So there was never any parallelism in this test case.