### PR TITLE
pipe::register_raw: Take ownership, don't dup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* (Breaking) `pipe::register_raw` now takes ownership and tries to use send
+  first, falls back to `O_NONBLOCK` and `write` on failure.
+
 # 0.1.16
 
 * Fix possible blocking in signal handler registered by `Signals`.

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -60,6 +60,7 @@ use std::sync::{Arc, Mutex};
 
 use libc::{self, c_int};
 
+use crate::pipe::{self, WakeMethod};
 use crate::SigId;
 
 /// Maximal signal number we support.
@@ -76,19 +77,7 @@ struct Waker {
 impl Waker {
     /// Sends a wakeup signal to the internal wakeup pipe.
     fn wake(&self) {
-        unsafe {
-            // See the comment at pipe::write.
-            //
-            // We don't use pipe::write, because it expects the FD to be already in non-blocking
-            // mode. That's because it needs to support actual pipes. We can afford send here,
-            // which has flags.
-            libc::send(
-                self.write.as_raw_fd(),
-                b"X" as *const _ as *const _,
-                1,
-                libc::MSG_DONTWAIT,
-            );
-        }
+        pipe::wake(self.write.as_raw_fd(), WakeMethod::Send);
     }
 }
 


### PR DESCRIPTION
Take ownership of the pipe. If the caller wants to dup it, they can.
Don't dup internally.

Set the O_NONBLOCK only if it can't be used with `send`.

Closes #41.

@johnbartholomew Could I ask you for second pair of eyes here?