### PR TITLE
Move adding of signals and closing of the iterator into a shareable handle

### DIFF
--- a/signal-hook-mio/src/lib.rs
+++ b/signal-hook-mio/src/lib.rs
@@ -28,7 +28,7 @@ macro_rules! implement_signals_with_pipe {
 
         /// A struct which mimics [`signal_hook::iterator::Signals`]
         /// but also allows usage together with MIO runtime.
-        pub struct Signals(SignalDelivery<Pipe, Pipe>);
+        pub struct Signals(SignalDelivery<Pipe>);
 
         pub use backend::Pending;
 
@@ -36,7 +36,7 @@ macro_rules! implement_signals_with_pipe {
             /// Create a `Signals` instance.
             ///
             /// This registers all the signals listed. The same restrictions (panics, errors) apply
-            /// as with [`Controller::add_signal`][backend::Controller::add_signal].
+            /// as with [`Handle::add_signal`][backend::Handle::add_signal].
             pub fn new<I, S>(signals: I) -> Result<Self, Error>
             where
                 I: IntoIterator<Item = S>,
@@ -50,9 +50,9 @@ macro_rules! implement_signals_with_pipe {
             /// Registers another signal to the set watched by this [`Signals`] instance.
             ///
             /// The same restrictions (panics, errors) apply as with
-            /// [`Controller::add_signal`][backend::Controller::add_signal].
+            /// [`Handle::add_signal`][backend::Handle::add_signal].
             pub fn add_signal(&self, signal: c_int) -> Result<(), Error> {
-                self.0.controller().add_signal(signal)
+                self.0.handle().add_signal(signal)
             }
 
             /// Returns an iterator of already received signals.

--- a/signal-hook-mio/src/lib.rs
+++ b/signal-hook-mio/src/lib.rs
@@ -36,7 +36,7 @@ macro_rules! implement_signals_with_pipe {
             /// Create a `Signals` instance.
             ///
             /// This registers all the signals listed. The same restrictions (panics, errors) apply
-            /// as with [`add_signal`][Signals::add_signal].
+            /// as with [`Controller::add_signal`][backend::Controller::add_signal].
             pub fn new<I, S>(signals: I) -> Result<Self, Error>
             where
                 I: IntoIterator<Item = S>,
@@ -49,20 +49,10 @@ macro_rules! implement_signals_with_pipe {
 
             /// Registers another signal to the set watched by this [`Signals`] instance.
             ///
-            /// # Notes
-            ///
-            /// * This is safe to call concurrently from whatever thread.
-            /// * This is *not* safe to call from within a signal handler.
-            /// * If the signal number was already registered previously, this is a no-op.
-            /// * If this errors, the original set of signals is left intact.
-            ///
-            /// # Panics
-            ///
-            /// * If the given signal is [forbidden][signal_hook::FORBIDDEN].
-            /// * If the signal number is negative or larger than internal limit. The limit should be
-            ///   larger than any supported signal the OS supports.
+            /// The same restrictions (panics, errors) apply as with
+            /// [`Controller::add_signal`][backend::Controller::add_signal].
             pub fn add_signal(&self, signal: c_int) -> Result<(), Error> {
-                self.0.add_signal(signal)
+                self.0.controller().add_signal(signal)
             }
 
             /// Returns an iterator of already received signals.
@@ -74,9 +64,8 @@ macro_rules! implement_signals_with_pipe {
             ///
             /// This method returns immediately (does not block) and may produce an empty iterator if there
             /// are no signals ready. So you should register an instance of this struct at an instance of
-            /// [`mio::Poll`] to query for readability of the underlying self pipe. The following example
-            /// shows this approach.
-            pub fn pending(&self) -> Pending {
+            /// [`mio::Poll`] to query for readability of the underlying self pipe.
+            pub fn pending(&mut self) -> Pending {
                 self.0.pending()
             }
         }
@@ -135,10 +124,7 @@ macro_rules! implement_signals_with_pipe {
 /// ```
 #[cfg(feature = "support-v0_7")]
 pub mod v0_7 {
-    use std::os::unix::io::AsRawFd;
-
     use mio::event::Source;
-    use mio::unix::SourceFd;
     use mio::{Interest, Registry, Token};
     use mio_0_7 as mio;
 
@@ -151,7 +137,7 @@ pub mod v0_7 {
             token: Token,
             interest: Interest,
         ) -> Result<(), Error> {
-            SourceFd(&self.0.get_read().as_raw_fd()).register(registry, token, interest)
+            self.0.get_read_mut().register(registry, token, interest)
         }
 
         fn reregister(
@@ -160,11 +146,11 @@ pub mod v0_7 {
             token: Token,
             interest: Interest,
         ) -> Result<(), Error> {
-            SourceFd(&self.0.get_read().as_raw_fd()).reregister(registry, token, interest)
+            self.0.get_read_mut().reregister(registry, token, interest)
         }
 
         fn deregister(&mut self, registry: &Registry) -> Result<(), Error> {
-            SourceFd(&self.0.get_read().as_raw_fd()).deregister(registry)
+            self.0.get_read_mut().deregister(registry)
         }
     }
 }

--- a/signal-hook-mio/tests/mio_0_6.rs
+++ b/signal-hook-mio/tests/mio_0_6.rs
@@ -15,7 +15,7 @@ use libc::c_int;
 #[test]
 #[serial]
 fn mio_wakeup() {
-    let signals = Signals::new(&[signal_hook::SIGUSR1]).unwrap();
+    let mut signals = Signals::new(&[signal_hook::SIGUSR1]).unwrap();
     let token = Token(0);
     let poll = Poll::new().unwrap();
     poll.register(&signals, token, Ready::readable(), PollOpt::level())
@@ -45,7 +45,7 @@ fn mio_wakeup() {
 #[test]
 #[serial]
 fn mio_multiple_signals() {
-    let signals = Signals::new(&[signal_hook::SIGUSR1, signal_hook::SIGUSR2]).unwrap();
+    let mut signals = Signals::new(&[signal_hook::SIGUSR1, signal_hook::SIGUSR2]).unwrap();
     let poll = Poll::new().unwrap();
     let token = Token(0);
     poll.register(&signals, token, Ready::readable(), PollOpt::level())
@@ -78,7 +78,7 @@ fn mio_multiple_signals() {
 #[test]
 #[serial]
 fn mio_parallel_multiple() {
-    let signals = Signals::new(&[signal_hook::SIGUSR1]).unwrap();
+    let mut signals = Signals::new(&[signal_hook::SIGUSR1]).unwrap();
     let poll = Poll::new().unwrap();
     let token = Token(0);
     poll.register(&signals, token, Ready::readable(), PollOpt::level())

--- a/signal-hook-tokio/src/lib.rs
+++ b/signal-hook-tokio/src/lib.rs
@@ -64,9 +64,9 @@ pub mod v0_1 {
 
     use std::borrow::Borrow;
     use std::io::Error;
-    use std::sync::Arc;
 
-    use signal_hook::iterator::backend::{Controller, PollResult, SignalDelivery, SignalIterator};
+    pub use signal_hook::iterator::backend::Handle;
+    use signal_hook::iterator::backend::{PollResult, SignalDelivery, SignalIterator};
 
     use futures_0_1::stream::Stream;
     use futures_0_1::{Async, Poll};
@@ -76,20 +76,17 @@ pub mod v0_1 {
     use tokio_0_1::io::AsyncRead;
     use tokio_0_1::net::unix::UnixStream;
 
-    /// A shareable handle to control an associated [`Signals`] instance.
-    pub type ControllerHandle = Arc<Controller<UnixStream>>;
-
     /// An asynchronous stream of arriving signals using the tokio runtime.
     ///
     /// The stream doesn't return the signals in the order they were recieved by
     /// the process and may merge signals received multiple times.
-    pub struct Signals(SignalIterator<UnixStream, UnixStream>);
+    pub struct Signals(SignalIterator<UnixStream>);
 
     impl Signals {
         /// Create a `Signals` instance.
         ///
         /// This registers all the signals listed. The same restrictions (panics, errors) apply
-        /// as with [`add_signal`][signal_hook::iterator::Signals::add_signal].
+        /// as with [`Handle::add_signal`].
         pub fn new<I, S>(signals: I) -> Result<Self, Error>
         where
             I: IntoIterator<Item = S>,
@@ -111,12 +108,12 @@ pub mod v0_1 {
             }
         }
 
-        /// Get a shareable handle to a [`Controller`] for this instance.
+        /// Get a shareable handle to a [`Handle`] for this instance.
         ///
         /// This can be used to add further signals or close the [`Signals`] instance
         /// which terminates the whole signal stream.
-        pub fn controller(&self) -> ControllerHandle {
-            self.0.controller()
+        pub fn handle(&self) -> Handle {
+            self.0.handle()
         }
     }
 

--- a/signal-hook-tokio/tests/tokio_0_1.rs
+++ b/signal-hook-tokio/tests/tokio_0_1.rs
@@ -62,7 +62,7 @@ fn delayed() {
 #[serial]
 fn close_signal_stream() {
     let mut signals = Signals::new(&[signal_hook::SIGUSR1, signal_hook::SIGUSR2]).unwrap();
-    signals.controller().close();
+    signals.handle().close();
 
     let async_result = signals.poll().unwrap();
 

--- a/signal-hook-tokio/tests/tokio_0_1.rs
+++ b/signal-hook-tokio/tests/tokio_0_1.rs
@@ -57,3 +57,14 @@ fn delayed() {
     // Just make sure it didn't terminate prematurely
     assert_eq!(CNT, cnt.load(Ordering::Relaxed));
 }
+
+#[test]
+#[serial]
+fn close_signal_stream() {
+    let mut signals = Signals::new(&[signal_hook::SIGUSR1, signal_hook::SIGUSR2]).unwrap();
+    signals.controller().close();
+
+    let async_result = signals.poll().unwrap();
+
+    assert_eq!(async_result, Async::Ready(None));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,9 +149,8 @@
 //! If you are looking for integration with an asynchronous runtime take a look at one of the
 //! following adapter crates:
 //!
-//! * [`signal-hook-mio`](https://docs.rs/signal-hook-mio) for mio support
-//! * [`signal-hook-mio-0_6`](https://docs.rs/signal-hook-mio-0_6) for mio 0.6 support
-//! * [`signal-hook-tokio-0_1`](https://docs.rs/signal-hook-tokio-0_1) for tokio 0.1 support
+//! * [`signal-hook-mio`](https://docs.rs/signal-hook-mio) for MIO support
+//! * [`signal-hook-tokio`](https://docs.rs/signal-hook-tokio) for Tokio support
 //!
 //! Feel free to open a pull requests if you want to add support for runtimes not mentioned above.
 

--- a/tests/iterator.rs
+++ b/tests/iterator.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use signal_hook::iterator::{ControllerHandle, Signals};
+use signal_hook::iterator::{Handle, Signals};
 use signal_hook::{SIGUSR1, SIGUSR2};
 
 use serial_test::serial;
@@ -22,15 +22,15 @@ fn send_sigusr2() {
     unsafe { libc::raise(SIGUSR2) };
 }
 
-fn setup_without_any_signals() -> (Signals, ControllerHandle) {
+fn setup_without_any_signals() -> (Signals, Handle) {
     let signals = Signals::new(&[]).unwrap();
-    let controller = signals.controller();
+    let controller = signals.handle();
     (signals, controller)
 }
 
-fn setup_for_sigusr2() -> (Signals, ControllerHandle) {
+fn setup_for_sigusr2() -> (Signals, Handle) {
     let signals = Signals::new(&[SIGUSR2]).unwrap();
-    let controller = signals.controller();
+    let controller = signals.handle();
     (signals, controller)
 }
 


### PR DESCRIPTION
I took a first shot at splitting the signal iterator into a non-clonable receiver and a shareable controller to manipulate it. For the API this means that:

* Cloning the Signals struct isn't possible any longer
* Pending and wait now expect a `&mut self` reference and forever will consume the Signals instance. Therefore `let mut` must be used for `Signals` instances
* This means there can be only one thread reading from the pipe

In exchange this allows to simplify the following things:

* The `flush` method doesn't have to write anything to the pipe because there won't be any other thread which has to be waked
* The MIO 0.7 implementation doesn't need the SourceFd / as_raw_fd workaround any longer because it is now possible to get a mutable reference to the reading half of `UnixStream`
* The has_signals callback can now accept a `&mut R` instead of `&mut &R`

**API discussion**

I'm a bit unsure about the API for getting controller handles. At the moment there are `controller()` methods spread across the different types. This also forces users to know about the dependency of one of their dependencies which doesn't feel right for me with respect to the "Law of Demeter".

The other option would be a channel like API with a construction function returning a tuple of receiver and controller. But for users of the synchronous `Signals` struct there might be some use cases which do not require such a handle (like the example in the iterator module documentation). So for those cases the channel like API seems to be awkward. On the other hand users of the `Forever` iterator or the Tokio adapter always want to get a handle or else they won't be able to shutdown their application properly. For those the channel like API seems to fit better.

At the moment I believe two different ways of construction may be the right thing to do. One for those not needing the handle. This will be the current `Signals::new` method. The other one being a module function returning a tuple of `Signals` and `Arc<Controller<W>>`. Then users have to decide at construction time depending on their use case but the `controller()` methods can go away.

I would love to know your thoughts about this.