### PR TITLE
actions: Don't run the tests twice on PR

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,6 @@ name: test
 
 on:
   push:
-  pull_request:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
It's enough they are run on push. Only some other workflows are pr-only
and need that.