### PR TITLE
Do not consume the Signals instance in the forever method

### DIFF
--- a/signal-hook-async-std/src/lib.rs
+++ b/signal-hook-async-std/src/lib.rs
@@ -64,7 +64,7 @@ use std::pin::Pin;
 use libc::c_int;
 
 pub use signal_hook::iterator::backend::Handle;
-use signal_hook::iterator::backend::{PollResult, SignalDelivery, SignalIterator};
+use signal_hook::iterator::backend::{OwningSignalIterator, PollResult, SignalDelivery};
 use signal_hook::iterator::exfiltrator::{Exfiltrator, SignalOnly};
 
 use async_std::os::unix::net::UnixStream;
@@ -77,7 +77,7 @@ use futures::AsyncRead;
 ///
 /// The stream doesn't return the signals in the order they were recieved by
 /// the process and may merge signals received multiple times.
-pub struct SignalsInfo<E: Exfiltrator = SignalOnly>(SignalIterator<UnixStream, E>);
+pub struct SignalsInfo<E: Exfiltrator = SignalOnly>(OwningSignalIterator<UnixStream, E>);
 
 impl<E: Exfiltrator> SignalsInfo<E> {
     /// Create a `Signals` instance.
@@ -101,7 +101,7 @@ impl<E: Exfiltrator> SignalsInfo<E> {
     {
         let (read, write) = UnixStream::pair()?;
         let inner = SignalDelivery::with_pipe(read, write, exfiltrator, signals)?;
-        Ok(Self(SignalIterator::new(inner)))
+        Ok(Self(OwningSignalIterator::new(inner)))
     }
 
     /// Get a shareable [`Handle`] for this `Signals` instance.

--- a/signal-hook-tokio/src/lib.rs
+++ b/signal-hook-tokio/src/lib.rs
@@ -22,14 +22,14 @@ macro_rules! implement_signals_with_pipe {
         use libc::c_int;
 
         pub use signal_hook::iterator::backend::Handle;
-        use signal_hook::iterator::backend::{SignalDelivery, SignalIterator};
+        use signal_hook::iterator::backend::{OwningSignalIterator, SignalDelivery};
         use signal_hook::iterator::exfiltrator::{Exfiltrator, SignalOnly};
 
         /// An asynchronous [`Stream`] of arriving signals.
         ///
         /// The stream doesn't return the signals in the order they were recieved by
         /// the process and may merge signals received multiple times.
-        pub struct SignalsInfo<E: Exfiltrator = SignalOnly>(SignalIterator<$pipe, E>);
+        pub struct SignalsInfo<E: Exfiltrator = SignalOnly>(OwningSignalIterator<$pipe, E>);
 
         impl<E: Exfiltrator> SignalsInfo<E> {
             /// Create a `SignalsInfo` instance.
@@ -53,7 +53,7 @@ macro_rules! implement_signals_with_pipe {
             {
                 let (read, write) = UnixStream::pair()?;
                 let inner = SignalDelivery::with_pipe(read, write, exfiltrator, signals)?;
-                Ok(Self(SignalIterator::new(inner)))
+                Ok(Self(OwningSignalIterator::new(inner)))
             }
 
             /// Get a shareable [`Handle`] for this `Signals` instance.

--- a/src/iterator/backend.rs
+++ b/src/iterator/backend.rs
@@ -17,7 +17,7 @@
 //! Use the [`Signals`][crate::iterator::Signals] struct or one of the types
 //! contained in the adapter libraries instead.
 
-use std::borrow::Borrow;
+use std::borrow::{Borrow, BorrowMut};
 use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::io::Error;
 use std::mem::MaybeUninit;
@@ -414,19 +414,20 @@ pub enum PollResult<O> {
 }
 
 /// An infinite iterator of received signals.
-pub struct SignalIterator<R, E: Exfiltrator> {
-    signals: SignalDelivery<R, E>,
+pub struct SignalIterator<SD, E: Exfiltrator> {
+    signals: SD,
     iter: Pending<E>,
 }
 
-impl<R, E: Exfiltrator> SignalIterator<R, E>
-where
-    R: 'static + AsRawFd + Send + Sync,
-{
+impl<SD, E: Exfiltrator> SignalIterator<SD, E> {
     /// Create a new infinite iterator for signals registered with the passed
     /// in [`SignalDelivery`] instance.
-    pub fn new(mut signals: SignalDelivery<R, E>) -> Self {
-        let iter = signals.pending();
+    pub fn new<R>(mut signals: SD) -> Self
+    where
+        SD: BorrowMut<SignalDelivery<R, E>>,
+        R: 'static + AsRawFd + Send + Sync,
+    {
+        let iter = signals.borrow_mut().pending();
         Self { signals, iter }
     }
 
@@ -441,19 +442,21 @@ where
     ///
     /// If the iterator was closed by the [`close`][Handle::close] method of the associtated
     /// [`Handle`] this method will return [`PollResult::Closed`].
-    pub fn poll_signal<F>(&mut self, has_signals: &mut F) -> PollResult<E::Output>
+    pub fn poll_signal<R, F>(&mut self, has_signals: &mut F) -> PollResult<E::Output>
     where
+        SD: BorrowMut<SignalDelivery<R, E>>,
+        R: 'static + AsRawFd + Send + Sync,
         F: FnMut(&mut R) -> Result<bool, Error>,
     {
         // The loop is necessary because it is possible that a signal was already consumed
         // by a previous pending iterator due to the asynchronous nature of signals and
         // always moving to the end of the iterator before calling has_more.
-        while !self.signals.handle.is_closed() {
+        while !self.signals.borrow_mut().handle.is_closed() {
             if let Some(result) = self.iter.next() {
                 return PollResult::Signal(result);
             }
 
-            match self.signals.poll_pending(has_signals) {
+            match self.signals.borrow_mut().poll_pending(has_signals) {
                 Ok(Some(pending)) => self.iter = pending,
                 Ok(None) => return PollResult::Pending,
                 Err(err) => return PollResult::Err(err),
@@ -467,13 +470,19 @@ where
     ///
     /// This can be used to add further signals or terminate the whole
     /// signal iteration using the [`close`][Handle::close] method.
-    pub fn handle(&self) -> Handle {
-        self.signals.handle()
-    }
-
-    /// Consume this iterator and return the inner
-    /// [`SignalDelivery`] instance.
-    pub fn into_inner(self) -> SignalDelivery<R, E> {
-        self.signals
+    pub fn handle<R>(&self) -> Handle
+    where
+        SD: Borrow<SignalDelivery<R, E>>,
+        R: 'static + AsRawFd + Send + Sync,
+    {
+        self.signals.borrow().handle()
     }
 }
+
+/// A signal iterator which consumes a [`SignalDelivery`] instance and takes
+/// ownership of it.
+pub type OwningSignalIterator<R, E> = SignalIterator<SignalDelivery<R, E>, E>;
+
+/// A signal iterator which takes a mutable reference to a [`SignalDelivery`]
+/// instance.
+pub type RefSignalIterator<'a, R, E> = SignalIterator<&'a mut SignalDelivery<R, E>, E>;

--- a/tests/cleanup.rs
+++ b/tests/cleanup.rs
@@ -64,7 +64,7 @@ fn cleanup_inside_signal() {
 #[test]
 fn cleanup_after_signal() {
     fn hook() {
-        let signals = signal_hook::iterator::Signals::new(&[libc::SIGTERM]).unwrap();
+        let mut signals = signal_hook::iterator::Signals::new(&[libc::SIGTERM]).unwrap();
         assert_eq!(Some(libc::SIGTERM), signals.into_iter().next());
         signal_hook::cleanup::cleanup_signal(libc::SIGTERM).unwrap();
     }

--- a/tests/iterator.rs
+++ b/tests/iterator.rs
@@ -51,7 +51,7 @@ macro_rules! assert_no_signals {
 #[test]
 #[serial]
 fn forever_terminates_when_closed() {
-    let (signals, controller) = setup_for_sigusr2();
+    let (mut signals, controller) = setup_for_sigusr2();
 
     // Detect early terminations.
     let stopped = Arc::new(AtomicBool::new(false));
@@ -60,7 +60,7 @@ fn forever_terminates_when_closed() {
     let thread = thread::spawn(move || {
         // Eat all the signals there are (might come from a concurrent test, in theory).
         // Would wait forever, but it should be terminated by the close below.
-        for _sig in signals {}
+        for _sig in &mut signals {}
 
         stopped_bg.store(true, Ordering::SeqCst);
     });
@@ -167,7 +167,7 @@ fn wait_returns_recieved_signals() {
 #[test]
 #[serial]
 fn forever_returns_recieved_signals() {
-    let (signals, _) = setup_for_sigusr2();
+    let (mut signals, _) = setup_for_sigusr2();
     send_sigusr2();
 
     let signal = signals.forever().take(1);
@@ -203,7 +203,7 @@ fn wait_unblocks_when_closed() {
 #[test]
 #[serial]
 fn forever_doesnt_block_when_closed() {
-    let (signals, controller) = setup_for_sigusr2();
+    let (mut signals, controller) = setup_for_sigusr2();
     controller.close();
 
     let mut signal = signals.forever();


### PR DESCRIPTION
This code should fix #70

This is a breaking change for the signal-hook crate but it isn't a breaking change for the adapter crates.