### PR TITLE
Remove futures dependency from async-std adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,7 +915,6 @@ name = "signal-hook-async-std"
 version = "0.1.0"
 dependencies = [
  "async-std",
- "futures 0.3.8",
  "libc",
  "serial_test",
  "signal-hook",

--- a/signal-hook-async-std/Cargo.toml
+++ b/signal-hook-async-std/Cargo.toml
@@ -22,7 +22,6 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 libc = "~0.2"
 async-std = "~1"
-futures = "~0.3"
 signal-hook = { version = "~0.2", path = ".." }
 
 [dev-dependencies]

--- a/signal-hook-async-std/src/lib.rs
+++ b/signal-hook-async-std/src/lib.rs
@@ -12,9 +12,7 @@
 //! ```rust
 //! use std::io::Error;
 //!
-//! use async_std;
-//!
-//! use futures::stream::StreamExt;
+//! use async_std::prelude::*;
 //!
 //! use signal_hook;
 //! use signal_hook_async_std::Signals;
@@ -67,11 +65,10 @@ pub use signal_hook::iterator::backend::Handle;
 use signal_hook::iterator::backend::{PollResult, SignalDelivery, SignalIterator};
 use signal_hook::iterator::exfiltrator::{Exfiltrator, SignalOnly};
 
+use async_std::io::Read;
 use async_std::os::unix::net::UnixStream;
-
-use futures::stream::Stream;
-use futures::task::{Context, Poll};
-use futures::AsyncRead;
+use async_std::stream::Stream;
+use async_std::task::{Context, Poll};
 
 /// An asynchronous [`Stream`] of arriving signals.
 ///

--- a/signal-hook-async-std/tests/async_std.rs
+++ b/signal-hook-async-std/tests/async_std.rs
@@ -1,4 +1,4 @@
-use futures::stream::StreamExt;
+use async_std::stream::StreamExt;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;


### PR DESCRIPTION
The `async-std` crate does not actually depend on the `futures` crate
for the types `Context`, `Poll`, `AsyncRead` (simply called `Read` in
`async-std`), `Stream`, and `StreamExt`. It instead relies on the
versions of `Context` and `Poll` from the Rust standard library, which
it re-exports, and provides its own definition of the `Read`, `Stream`,
and `StreamExt` traits. For this reason users of the
`signal-hook-async-std` crate are unlikely to depend on the `futures`
crate themselves, making this crate's dependency on `futures`
unnecessary.

This commit replaces these types with the versions from `async-std` and
removes the `futures` dependency from the `signal-hook-async-std` crate.

In another project I am working on that uses `signal-hook` and
`async-std`, this change removed the following 10 crates from my
dependency list:

- futures
- futures-executor
- futures-macro
- futures-sink
- futures-task
- futures-util
- pin-project
- pin-project-internal
- proc-macro-hack
- proc-macro-nested