### PR TITLE
iterator feature requires channel feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "actively-developed" }
 [features]
 channel = []
 default = ["channel", "iterator"]
-iterator = []
+iterator = ["channel"]
 # TODO: Unify them on the next breaking release.
 extended-siginfo = ["channel", "iterator", "extended-siginfo-raw"]
 extended-siginfo-raw = ["cc"]


### PR DESCRIPTION
In signal-hook 0.3.3, iterator feature requires channel feature, but currently, it is not specified and we will get the following compilation error:

```console
$ cargo check --no-default-features --features iterator
   Compiling signal-hook v0.3.3 ...

error[E0432]: unresolved import `crate::low_level::channel`
  --> src/iterator/exfiltrator/raw.rs:17:23
   |
17 | use crate::low_level::channel::Channel;
   |                       ^^^^^^^ could not find `channel` in `low_level`

error[E0283]: type annotations needed
  --> src/iterator/exfiltrator/raw.rs:21:17
   |
21 | pub struct Slot(AtomicPtr<Channel<siginfo_t>>);
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
   |
   = note: cannot satisfy `_: Default`
   = note: required by `std::default::Default::default`
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

I confirmed the issue fixed by this patch and confirmed there were no other similar issues by using [cargo-hack](https://github.com/taiki-e/cargo-hack#--feature-powerset):

```sh
cargo hack check --feature-powerset --no-dev-deps --all
```
