### PR TITLE
signal-hook-async-std: Switch to using async-io + futures-lite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,7 +701,9 @@ dependencies = [
 name = "signal-hook-async-std"
 version = "0.2.0"
 dependencies = [
+ "async-io",
  "async-std",
+ "futures-lite",
  "libc",
  "serial_test",
  "signal-hook",

--- a/signal-hook-async-std/Cargo.toml
+++ b/signal-hook-async-std/Cargo.toml
@@ -21,7 +21,8 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 libc = "~0.2"
-async-std = "~1"
+async-io = "~1"
+futures-lite = "~1"
 signal-hook = { version = "~0.3", path = ".." }
 
 [dev-dependencies]


### PR DESCRIPTION
Switch to async-std's underlying async-io and futures-lite crates for
better compatibility with smol and using fewer dependencies in general.
Doing this also does not substantially changing the code, which is a
plus.