### PR TITLE
Unmask the signal when emulating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.7
+
+* Unmask a signal in default emulation if it is termination.
+
 # mio-0.2.2
 
 * The same fix, but for the 0.6 support 😇.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signal-hook"
-version = "0.3.6"
+version = "0.3.7"
 authors = [
     "Michal 'vorner' Vaner <vorner@vorner.cz>",
     "Thomas Himmelstoss <thimm@posteo.de>",


### PR DESCRIPTION
When emulating a termination signal, unmask it in case it is masked, so
it may work.