### PR TITLE
Remove duplicate cfg_attr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
     test(attr(deny(warnings))),
     test(attr(allow(bare_trait_objects, unknown_lints)))
 )]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 // Don't fail on links to things not enabled in features
 #![allow(


### PR DESCRIPTION
This removes the duplicate `cfg_attr` that is leading to docs.rs build failures.

I ran the docs.rs build locally and it finished successfully - though strangely it's failing for 0.3.6 whereas their build finished successfully (even though both `cfg_attr`s are already there)