### PR TITLE
Remove `SA_NOCLDSTOP` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,12 +691,12 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.8"
+version = "0.4.0"
 dependencies = [
  "cc",
  "libc",
  "serial_test",
- "signal-hook-registry 1.3.0",
+ "signal-hook-registry 1.4.0",
 ]
 
 [[package]]
@@ -726,18 +726,18 @@ dependencies = [
 [[package]]
 name = "signal-hook-registry"
 version = "1.3.0"
-dependencies = [
- "libc",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+dependencies = [
+ "libc",
+ "signal-hook",
 ]
 
 [[package]]
@@ -801,7 +801,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pin-project-lite",
- "signal-hook-registry 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook-registry 1.3.0",
  "tokio-macros",
  "winapi 0.3.9",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signal-hook"
-version = "0.3.8"
+version = "0.4.0"
 authors = [
     "Michal 'vorner' Vaner <vorner@vorner.cz>",
     "Thomas Himmelstoss <thimm@posteo.de>",
@@ -35,7 +35,7 @@ members = [
 
 [dependencies]
 libc = "^0.2"
-signal-hook-registry = { version = "^1.3", path = "signal-hook-registry" }
+signal-hook-registry = { version = "^1.4", path = "signal-hook-registry" }
 
 [dev-dependencies]
 serial_test = "^0.5"

--- a/signal-hook-async-std/Cargo.toml
+++ b/signal-hook-async-std/Cargo.toml
@@ -23,7 +23,7 @@ maintenance = { status = "actively-developed" }
 libc = "~0.2"
 async-io = "~1"
 futures-lite = "~1"
-signal-hook = { version = "~0.3", path = ".." }
+signal-hook = { version = "~0.4", path = ".." }
 
 [dev-dependencies]
 async-std = { version = "~1", features = ["attributes"] }

--- a/signal-hook-mio/Cargo.toml
+++ b/signal-hook-mio/Cargo.toml
@@ -25,7 +25,7 @@ support-v0_7 = ["mio-0_7"]
 
 [dependencies]
 libc = "~0.2"
-signal-hook = { version = "~0.3", path = ".." }
+signal-hook = { version = "~0.4", path = ".." }
 mio-0_7 = { package = "mio", version = "~0.7", features = ["os-util", "uds"], optional = true}
 mio-0_6 = { package = "mio", version = "~0.6", optional = true}
 mio-uds = { version = "~0.6", optional = true}

--- a/signal-hook-registry/Cargo.toml
+++ b/signal-hook-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signal-hook-registry"
-version = "1.3.0"
+version = "1.4.0"
 authors = [
     "Michal 'vorner' Vaner <vorner@vorner.cz>",
     "Masaki Hara <ackie.h.gmai@gmail.com>",
@@ -21,4 +21,4 @@ maintenance = { status = "actively-developed" }
 libc = "~0.2"
 
 [dev-dependencies]
-signal-hook = { version = "~0.3", path = ".." }
+signal-hook = { version = "~0.4", path = ".." }

--- a/signal-hook-registry/src/lib.rs
+++ b/signal-hook-registry/src/lib.rs
@@ -162,7 +162,7 @@ impl Slot {
         // Android is broken and uses different int types than the rest (and different depending on
         // the pointer width). This converts the flags to the proper type no matter what it is on
         // the given platform.
-        let flags = libc::SA_RESTART | libc::SA_NOCLDSTOP;
+        let flags = libc::SA_RESTART;
         #[allow(unused_assignments)]
         let mut siginfo = flags;
         siginfo = libc::SA_SIGINFO as _;

--- a/signal-hook-tokio/Cargo.toml
+++ b/signal-hook-tokio/Cargo.toml
@@ -24,7 +24,7 @@ futures-v0_3 = ["futures-core-0_3"]
 
 [dependencies]
 libc = "~0.2"
-signal-hook = { version = "~0.3", path = ".." }
+signal-hook = { version = "~0.4", path = ".." }
 futures-core-0_3 = { package = "futures-core", version = "~0.3", optional = true }
 tokio = { version = "~1", features = ["net"] }
 


### PR DESCRIPTION
Hey!

I am using ptrace with tokio and I need to wait for the SIGCHLD every time the process stops. But `SA_NOCLDSTOP` disables this feature. I don't know why it is set. You can find my investigation here https://github.com/tokio-rs/tokio/issues/3804 😄