### PR TITLE
Don't use sigemptyset and sigaddset on Android

### DIFF
--- a/src/low_level/signal_details.rs
+++ b/src/low_level/signal_details.rs
@@ -172,6 +172,16 @@ pub fn emulate_default_handler(signal: c_int) -> Result<(), Error> {
         DefaultKind::Stop => low_level::raise(SIGSTOP),
         DefaultKind::Term => {
             if let Ok(()) = restore_default(signal) {
+                // `sigemptyset` and `sigaddset` are not available on old Android versions before
+                // API 21 (Android 5.0).
+                // Unfortunately, we can't do conditional compilation based on the Android version,
+                // so we disable the code for all Android versions.
+                // As these old Android versions don't support 64-Bit-code anyway, we can leave
+                // the code enabled for 64-Bit-code.
+                #[cfg(not(all(
+                    target_os = "android",
+                    any(target_pointer_width = "32", target_pointer_width = "16")
+                )))]
                 #[cfg(not(windows))]
                 unsafe {
                     #[allow(deprecated)]


### PR DESCRIPTION
Fix https://github.com/vorner/signal-hook/issues/118.

I successfully tested this by [overriding the dependency](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html) to `signal-hook` in DeltaChat's local Cargo.toml:

```
[patch.crates-io]
signal-hook = { path = "../../../signal-hook" }
```

and running `./ndk-make.sh armeabi-v7a` and `./ndk-make.sh x86` (ndk-make.sh is our build script).

[64-bit support was added in android-21](https://stackoverflow.com/questions/49714180/why-android-ndk-standalone-toolchain-do-not-support-arm64-with-api-19-but-androi), so it's fine to only disable the code for 32-Bit Android code.

I didn't add this to the CI as this would be quite complicated because it's `ndk-build` that fails, not compiling (at least I couldn't come up with an easier way): We would have to let the CI download the Android SDK, write an Android.mk and Application.mk file, and run [ndk-build](https://developer.android.com/ndk/guides/ndk-build). And possibly do some other things to make `ndk-build` think that it's building an Android app.