### PR TITLE
add haiku support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,24 +367,21 @@ pub mod consts {
     /// namespace with other names. Also available in the [`consts`][crate::consts] directly (but
     /// with more constants around).
     pub mod signal {
-        #[cfg(not(any(windows, target_os = "haiku")))]
-        pub use libc::{
-            SIGABRT, SIGALRM, SIGBUS, SIGCHLD, SIGCONT, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGIO,
-            SIGKILL, SIGPIPE, SIGPROF, SIGQUIT, SIGSEGV, SIGSTOP, SIGSYS, SIGTERM, SIGTRAP,
-            SIGTSTP, SIGTTIN, SIGTTOU, SIGURG, SIGUSR1, SIGUSR2, SIGVTALRM, SIGWINCH, SIGXCPU,
-            SIGXFSZ,
-        };
-
-        #[cfg(windows)]
-        pub use libc::{SIGABRT, SIGFPE, SIGILL, SIGINT, SIGSEGV, SIGTERM};
-
-        #[cfg(target_os = "haiku")]
+        #[cfg(not(windows))]
         pub use libc::{
             SIGABRT, SIGALRM, SIGBUS, SIGCHLD, SIGCONT, SIGFPE, SIGHUP, SIGILL, SIGINT,
             SIGKILL, SIGPIPE, SIGPROF, SIGQUIT, SIGSEGV, SIGSTOP, SIGSYS, SIGTERM, SIGTRAP,
             SIGTSTP, SIGTTIN, SIGTTOU, SIGURG, SIGUSR1, SIGUSR2, SIGVTALRM, SIGWINCH, SIGXCPU,
             SIGXFSZ,
         };
+
+        #[cfg(not(any(windows, target_os = "haiku")))]
+        pub use libc::{
+            SIGIO,
+        };
+
+        #[cfg(windows)]
+        pub use libc::{SIGABRT, SIGFPE, SIGILL, SIGINT, SIGSEGV, SIGTERM};
 
         // NOTE: they perhaps deserve backport to libc.
         #[cfg(windows)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,7 +367,7 @@ pub mod consts {
     /// namespace with other names. Also available in the [`consts`][crate::consts] directly (but
     /// with more constants around).
     pub mod signal {
-        #[cfg(not(windows))]
+        #[cfg(not(any(windows, target_os = "haiku")))]
         pub use libc::{
             SIGABRT, SIGALRM, SIGBUS, SIGCHLD, SIGCONT, SIGFPE, SIGHUP, SIGILL, SIGINT, SIGIO,
             SIGKILL, SIGPIPE, SIGPROF, SIGQUIT, SIGSEGV, SIGSTOP, SIGSYS, SIGTERM, SIGTRAP,
@@ -377,6 +377,14 @@ pub mod consts {
 
         #[cfg(windows)]
         pub use libc::{SIGABRT, SIGFPE, SIGILL, SIGINT, SIGSEGV, SIGTERM};
+
+        #[cfg(target_os = "haiku")]
+        pub use libc::{
+            SIGABRT, SIGALRM, SIGBUS, SIGCHLD, SIGCONT, SIGFPE, SIGHUP, SIGILL, SIGINT,
+            SIGKILL, SIGPIPE, SIGPROF, SIGQUIT, SIGSEGV, SIGSTOP, SIGSYS, SIGTERM, SIGTRAP,
+            SIGTSTP, SIGTTIN, SIGTTOU, SIGURG, SIGUSR1, SIGUSR2, SIGVTALRM, SIGWINCH, SIGXCPU,
+            SIGXFSZ,
+        };
 
         // NOTE: they perhaps deserve backport to libc.
         #[cfg(windows)]

--- a/src/low_level/pipe.rs
+++ b/src/low_level/pipe.rs
@@ -229,6 +229,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "haiku"))]
     fn register_dgram_socket() -> Result<(), Error> {
         let (read, write) = UnixDatagram::pair()?;
         register(libc::SIGUSR1, write)?;

--- a/src/low_level/signal_details.rs
+++ b/src/low_level/signal_details.rs
@@ -35,7 +35,7 @@ macro_rules! s {
     };
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "haiku")))]
+#[cfg(not(windows))]
 const DETAILS: &[Details] = &[
     s!(SIGABRT, Term),
     s!(SIGALRM, Term),
@@ -47,43 +47,8 @@ const DETAILS: &[Details] = &[
     s!(SIGHUP, Term),
     s!(SIGILL, Term),
     s!(SIGINT, Term),
+    #[cfg(not(target_os = "haiku"))]
     s!(SIGIO, Ignore),
-    // Can't override anyway, but...
-    s!(SIGKILL, Term),
-    s!(SIGPIPE, Term),
-    s!(SIGPROF, Term),
-    s!(SIGQUIT, Term),
-    s!(SIGSEGV, Term),
-    // Can't override anyway, but...
-    s!(SIGSTOP, Stop),
-    s!(SIGSYS, Term),
-    s!(SIGTERM, Term),
-    s!(SIGTRAP, Term),
-    s!(SIGTSTP, Stop),
-    s!(SIGTTIN, Stop),
-    s!(SIGTTOU, Stop),
-    s!(SIGURG, Ignore),
-    s!(SIGUSR1, Term),
-    s!(SIGUSR2, Term),
-    s!(SIGVTALRM, Term),
-    s!(SIGWINCH, Ignore),
-    s!(SIGXCPU, Term),
-    s!(SIGXFSZ, Term),
-];
-
-#[cfg(target_os = "haiku")]
-const DETAILS: &[Details] = &[
-    s!(SIGABRT, Term),
-    s!(SIGALRM, Term),
-    s!(SIGBUS, Term),
-    s!(SIGCHLD, Ignore),
-    // Technically, continue the process... but this is not done *by* the process.
-    s!(SIGCONT, Ignore),
-    s!(SIGFPE, Term),
-    s!(SIGHUP, Term),
-    s!(SIGILL, Term),
-    s!(SIGINT, Term),
-    //s!(SIGIO, Ignore),
     // Can't override anyway, but...
     s!(SIGKILL, Term),
     s!(SIGPIPE, Term),

--- a/src/low_level/signal_details.rs
+++ b/src/low_level/signal_details.rs
@@ -35,7 +35,7 @@ macro_rules! s {
     };
 }
 
-#[cfg(not(windows))]
+#[cfg(not(any(target_os = "windows", target_os = "haiku")))]
 const DETAILS: &[Details] = &[
     s!(SIGABRT, Term),
     s!(SIGALRM, Term),
@@ -48,6 +48,42 @@ const DETAILS: &[Details] = &[
     s!(SIGILL, Term),
     s!(SIGINT, Term),
     s!(SIGIO, Ignore),
+    // Can't override anyway, but...
+    s!(SIGKILL, Term),
+    s!(SIGPIPE, Term),
+    s!(SIGPROF, Term),
+    s!(SIGQUIT, Term),
+    s!(SIGSEGV, Term),
+    // Can't override anyway, but...
+    s!(SIGSTOP, Stop),
+    s!(SIGSYS, Term),
+    s!(SIGTERM, Term),
+    s!(SIGTRAP, Term),
+    s!(SIGTSTP, Stop),
+    s!(SIGTTIN, Stop),
+    s!(SIGTTOU, Stop),
+    s!(SIGURG, Ignore),
+    s!(SIGUSR1, Term),
+    s!(SIGUSR2, Term),
+    s!(SIGVTALRM, Term),
+    s!(SIGWINCH, Ignore),
+    s!(SIGXCPU, Term),
+    s!(SIGXFSZ, Term),
+];
+
+#[cfg(target_os = "haiku")]
+const DETAILS: &[Details] = &[
+    s!(SIGABRT, Term),
+    s!(SIGALRM, Term),
+    s!(SIGBUS, Term),
+    s!(SIGCHLD, Ignore),
+    // Technically, continue the process... but this is not done *by* the process.
+    s!(SIGCONT, Ignore),
+    s!(SIGFPE, Term),
+    s!(SIGHUP, Term),
+    s!(SIGILL, Term),
+    s!(SIGINT, Term),
+    //s!(SIGIO, Ignore),
     // Can't override anyway, but...
     s!(SIGKILL, Term),
     s!(SIGPIPE, Term),


### PR DESCRIPTION
hello,

this adds haiku support per #119. if there is a more idiomatic way to handle this, would be open to suggestions.

the following shows a run of the unit tests  (after successful compilation) in which currently only one test doesn't pass.  my guess is that this test for haiku can probably be suppressed as it is unclear if datagram over unix sockets in haiku is currently available.

thanks!

```
> uname -a
Haiku shredder 1 hrev55602 Oct 29 2021 07:10:38 x86_64 x86_64 Haiku

> cargo test
  Downloaded proc-macro2 v1.0.33
  Downloaded 1 crate (41.0 KB) in 0.51s
   Compiling proc-macro2 v1.0.33
   Compiling syn v1.0.82
   Compiling smallvec v1.7.0
   Compiling instant v0.1.12
   Compiling parking_lot_core v0.8.5
   Compiling parking_lot v0.11.2
   Compiling quote v1.0.10
   Compiling serial_test_derive v0.5.1
   Compiling serial_test v0.5.1
   Compiling signal-hook v0.3.12 (/boot/home/src/git/rust-libs/signal-hook)
    Finished test [unoptimized + debuginfo] target(s) in 1m 09s
     Running unittests (target/debug/deps/signal_hook-dcf2f73007120844)

running 11 tests
test flag::tests::register_unregister ... ok
test low_level::channel::tests::multi_thread ... ok
test low_level::channel::tests::multiple ... ok
test low_level::channel::tests::new_empty ... ok
test low_level::channel::tests::overflow ... ok
test low_level::channel::tests::pass_value ... ok
test low_level::pipe::tests::register_dgram_socket ... FAILED
test low_level::pipe::tests::register_with_pipe ... ok
test low_level::pipe::tests::register_with_socket ... ok
test low_level::signal_details::test::existing ... ok
test low_level::signal_details::test::unknown ... ok

failures:

---- low_level::pipe::tests::register_dgram_socket stdout ----
Error: Os { code: -2147454955, kind: Uncategorized, message: "Address family not supported by protocol family" }
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /mnt/d/Rust/rust-x86/library/test/src/lib.rs:194:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```