### PR TITLE
Add support for mio v0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba42135c6a5917b9db9cd7b293e5409e1c6b041e6f9825e92e55a894c63b6f8"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.7",
+ "ntapi",
+ "wasi",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "mio-uds"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +715,7 @@ dependencies = [
  "libc",
  "mio 0.6.23",
  "mio 0.7.14",
+ "mio 0.8.1",
  "mio-uds",
  "serial_test",
  "signal-hook",
@@ -826,6 +841,12 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/signal-hook-mio/Cargo.toml
+++ b/signal-hook-mio/Cargo.toml
@@ -22,12 +22,14 @@ maintenance = { status = "actively-developed" }
 [features]
 support-v0_6 = ["mio-0_6", "mio-uds"]
 support-v0_7 = ["mio-0_7"]
+support-v0_8 = ["mio-0_8"]
 
 [dependencies]
 libc = "~0.2"
 signal-hook = { version = "~0.3", path = ".." }
-mio-0_7 = { package = "mio", version = "~0.7", features = ["os-util", "uds"], optional = true}
-mio-0_6 = { package = "mio", version = "~0.6", optional = true}
+mio-0_8 = { package = "mio", version = "~0.8", features = ["net", "os-ext"], optional = true }
+mio-0_7 = { package = "mio", version = "~0.7", features = ["os-util", "uds"], optional = true }
+mio-0_6 = { package = "mio", version = "~0.6", optional = true }
 mio-uds = { version = "~0.6", optional = true}
 
 [dev-dependencies]

--- a/signal-hook-mio/src/lib.rs
+++ b/signal-hook-mio/src/lib.rs
@@ -10,10 +10,15 @@
 //!
 //! * `support-v0_6` for sub module [`v0_6`]
 //! * `support-v0_7` for sub module [`v0_7`]
+//! * `support-v0_8` for sub module [`v0_8`]
 //!
 //! See the specific sub modules for usage examples.
 
-#[cfg(any(feature = "support-v0_6", feature = "support-v0_7"))]
+#[cfg(any(
+    feature = "support-v0_6",
+    feature = "support-v0_7",
+    feature = "support-v0_8"
+))]
 macro_rules! implement_signals_with_pipe {
     ($pipe:path) => {
         use std::borrow::Borrow;
@@ -87,6 +92,98 @@ macro_rules! implement_signals_with_pipe {
         /// one you want to use.
         pub type Signals = SignalsInfo<SignalOnly>;
     };
+}
+
+/// A module for integrating signal handling with the MIO 0.8 runtime.
+///
+/// This provides the [`Signals`][v0_8::Signals] struct as an abstraction
+/// which can be used with [`mio::Poll`][mio_0_8::Poll].
+///
+/// # Examples
+///
+/// ```rust
+/// # use mio_0_8 as mio;
+/// use std::io::{Error, ErrorKind};
+///
+/// use signal_hook::consts::signal::*;
+/// use signal_hook_mio::v0_8::Signals;
+///
+/// use mio::{Events, Poll, Interest, Token};
+///
+/// fn main() -> Result<(), Error> {
+///     let mut poll = Poll::new()?;
+///
+///     let mut signals = Signals::new(&[
+///         SIGTERM,
+/// #       SIGUSR1,
+///     ])?;
+///
+///     let signal_token = Token(0);
+///
+///     poll.registry().register(&mut signals, signal_token, Interest::READABLE)?;
+/// #   signal_hook::low_level::raise(SIGUSR1).unwrap(); // Just for terminating the example
+///
+///     let mut events = Events::with_capacity(10);
+///     'outer: loop {
+///         poll.poll(&mut events, None)
+///             .or_else(|e| if e.kind() == ErrorKind::Interrupted {
+///                 // We get interrupt when a signal happens inside poll. That's non-fatal, just
+///                 // retry.
+///                 events.clear();
+///                 Ok(())
+///             } else {
+///                 Err(e)
+///             })?;
+///         for event in events.iter() {
+///             match event.token() {
+///                 Token(0) => {
+///                     for signal in signals.pending() {
+///                         match signal {
+///                             SIGTERM => break 'outer,
+/// #                           SIGUSR1 => return Ok(()),
+///                             _ => unreachable!(),
+///                         }
+///                     }
+///                 },
+///                 _ => unreachable!("Register other sources and match for their tokens here"),
+///             }
+///         }
+///     }
+///
+///     Ok(())
+/// }
+/// ```
+#[cfg(feature = "support-v0_8")]
+pub mod v0_8 {
+    use mio::event::Source;
+    use mio::{Interest, Registry, Token};
+    use mio_0_8 as mio;
+
+    implement_signals_with_pipe!(mio::net::UnixStream);
+
+    impl Source for Signals {
+        fn register(
+            &mut self,
+            registry: &Registry,
+            token: Token,
+            interest: Interest,
+        ) -> Result<(), Error> {
+            self.0.get_read_mut().register(registry, token, interest)
+        }
+
+        fn reregister(
+            &mut self,
+            registry: &Registry,
+            token: Token,
+            interest: Interest,
+        ) -> Result<(), Error> {
+            self.0.get_read_mut().reregister(registry, token, interest)
+        }
+
+        fn deregister(&mut self, registry: &Registry) -> Result<(), Error> {
+            self.0.get_read_mut().deregister(registry)
+        }
+    }
 }
 
 /// A module for integrating signal handling with the MIO 0.7 runtime.

--- a/signal-hook-mio/tests/mio_0_7.rs
+++ b/signal-hook-mio/tests/mio_0_7.rs
@@ -1,15 +1,21 @@
-#![cfg(feature = "support-v0_7")]
+#![cfg(any(feature = "support-v0_7", feature = "support-v0_8"))]
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
+#[cfg(all(feature = "support-v0_7", not(feature = "support-v0_8")))]
 use mio_0_7::{Events, Interest, Poll, Token};
+#[cfg(feature = "support-v0_8")]
+use mio_0_8::{Events, Interest, Poll, Token};
 
 use signal_hook::consts::{SIGUSR1, SIGUSR2};
 use signal_hook::low_level::raise;
+#[cfg(all(feature = "support-v0_7", not(feature = "support-v0_8")))]
 use signal_hook_mio::v0_7::Signals;
+#[cfg(feature = "support-v0_8")]
+use signal_hook_mio::v0_8::Signals;
 
 use serial_test::serial;
 

--- a/signal-hook-mio/tests/mio_0_8.rs
+++ b/signal-hook-mio/tests/mio_0_8.rs
@@ -1,15 +1,15 @@
-#![cfg(feature = "support-v0_7")]
+#![cfg(feature = "support-v0_8")]
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use mio_0_7::{Events, Interest, Poll, Token};
+use mio_0_8::{Events, Interest, Poll, Token};
 
 use signal_hook::consts::{SIGUSR1, SIGUSR2};
 use signal_hook::low_level::raise;
-use signal_hook_mio::v0_7::Signals;
+use signal_hook_mio::v0_8::Signals;
 
 use serial_test::serial;
 


### PR DESCRIPTION
Add support for mio-v0.8, not sure if this is the best way since it duplicates most of the v0.7, also not sure if there is a better way for this doing this, this allows helix which in terms depends on crossterm to be able to use signal-hook-mio with v0.8 to prevent crate duplication.