### PR TITLE
Support AIX signal handler types

### DIFF
--- a/signal-hook-registry/src/lib.rs
+++ b/signal-hook-registry/src/lib.rs
@@ -159,12 +159,9 @@ impl Slot {
         // C data structure, expected to be zeroed out.
         let mut new: libc::sigaction = unsafe { mem::zeroed() };
         #[cfg(not(target_os = "aix"))]
-        let set_handler =
-            |action: &mut libc::sigaction, handler| action.sa_sigaction = handler as usize;
+        { new.sa_sigaction = handler as usize; }
         #[cfg(target_os = "aix")]
-        let set_handler =
-            |action: &mut libc::sigaction, handler| action.sa_union.__su_sigaction = handler;
-        set_handler(&mut new, handler);
+        { new.sa_union.__su_sigaction = handler; }
         // Android is broken and uses different int types than the rest (and different depending on
         // the pointer width). This converts the flags to the proper type no matter what it is on
         // the given platform.

--- a/signal-hook-registry/src/lib.rs
+++ b/signal-hook-registry/src/lib.rs
@@ -158,7 +158,13 @@ impl Slot {
     fn new(signal: libc::c_int) -> Result<Self, Error> {
         // C data structure, expected to be zeroed out.
         let mut new: libc::sigaction = unsafe { mem::zeroed() };
-        new.sa_sigaction = handler as usize;
+        #[cfg(not(target_os = "aix"))]
+        let set_handler =
+            |action: &mut libc::sigaction, handler| action.sa_sigaction = handler as usize;
+        #[cfg(target_os = "aix")]
+        let set_handler =
+            |action: &mut libc::sigaction, handler| action.sa_union.__su_sigaction = handler;
+        set_handler(&mut new, handler);
         // Android is broken and uses different int types than the rest (and different depending on
         // the pointer width). This converts the flags to the proper type no matter what it is on
         // the given platform.
@@ -232,7 +238,10 @@ impl Prev {
 
     #[cfg(not(windows))]
     unsafe fn execute(&self, sig: c_int, info: *mut siginfo_t, data: *mut c_void) {
+        #[cfg(not(target_os = "aix"))]
         let fptr = self.info.sa_sigaction;
+        #[cfg(target_os = "aix")]
+        let fptr = self.info.sa_union.__su_sigaction as usize;
         if fptr != 0 && fptr != libc::SIG_DFL && fptr != libc::SIG_IGN {
             // Android is broken and uses different int types than the rest (and different
             // depending on the pointer width). This converts the flags to the proper type no

--- a/src/iterator/backend.rs
+++ b/src/iterator/backend.rs
@@ -309,11 +309,15 @@ where
             // should not be something like closed file descriptor. It could EAGAIN, but
             // that's OK in case we say MSG_DONTWAIT. If it's EINTR, then it's OK too,
             // it'll only create a spurious wakeup.
+            #[cfg(target_os = "aix")]
+            let nowait_flag = libc::MSG_NONBLOCK;
+            #[cfg(not(target_os = "aix"))]
+            let nowait_flag = libc::MSG_DONTWAIT;
             while libc::recv(
                 self.read.as_raw_fd(),
                 buff.as_mut_ptr() as *mut libc::c_void,
                 SIZE,
-                libc::MSG_DONTWAIT,
+                nowait_flag,
             ) > 0
             {}
         }

--- a/src/low_level/pipe.rs
+++ b/src/low_level/pipe.rs
@@ -81,6 +81,11 @@ use libc::{self, c_int};
 
 use crate::SigId;
 
+#[cfg(target_os = "aix")]
+const MSG_NOWAIT: i32 = libc::MSG_NONBLOCK;
+#[cfg(not(target_os = "aix"))]
+const MSG_NOWAIT: i32 = libc::MSG_DONTWAIT;
+
 #[derive(Copy, Clone)]
 pub(crate) enum WakeMethod {
     Send,
@@ -141,10 +146,7 @@ pub(crate) fn wake(pipe: RawFd, method: WakeMethod) {
         let data = b"X" as *const _ as *const _;
         match method {
             WakeMethod::Write => libc::write(pipe, data, 1),
-            #[cfg(target_os = "aix")]
-            WakeMethod::Send => libc::send(pipe, data, 1, libc::MSG_NONBLOCK),
-            #[cfg(not(target_os = "aix"))]
-            WakeMethod::Send => libc::send(pipe, data, 1, libc::MSG_DONTWAIT),
+            WakeMethod::Send => libc::send(pipe, data, 1, MSG_NOWAIT),
         };
     }
 }
@@ -173,10 +175,7 @@ pub(crate) fn wake(pipe: RawFd, method: WakeMethod) {
 /// * If it is not possible, the [`O_NONBLOCK`][libc::O_NONBLOCK] will be set on the file
 ///   descriptor and [`write`][libc::write] will be used instead.
 pub fn register_raw(signal: c_int, pipe: RawFd) -> Result<SigId, Error> {
-    #[cfg(not(target_os = "aix"))]
-    let res = unsafe { libc::send(pipe, &[] as *const _, 0, libc::MSG_DONTWAIT) };
-    #[cfg(target_os = "aix")]
-    let res = unsafe { libc::send(pipe, &[] as *const _, 0, libc::MSG_NONBLOCK) };
+    let res = unsafe { libc::send(pipe, &[] as *const _, 0, MSG_NOWAIT) };
     let fd = match (res, Error::last_os_error().kind()) {
         (0, _) | (-1, ErrorKind::WouldBlock) => WakeFd {
             fd: pipe,

--- a/src/low_level/pipe.rs
+++ b/src/low_level/pipe.rs
@@ -141,6 +141,9 @@ pub(crate) fn wake(pipe: RawFd, method: WakeMethod) {
         let data = b"X" as *const _ as *const _;
         match method {
             WakeMethod::Write => libc::write(pipe, data, 1),
+            #[cfg(target_os = "aix")]
+            WakeMethod::Send => libc::send(pipe, data, 1, libc::MSG_NONBLOCK),
+            #[cfg(not(target_os = "aix"))]
             WakeMethod::Send => libc::send(pipe, data, 1, libc::MSG_DONTWAIT),
         };
     }
@@ -170,7 +173,10 @@ pub(crate) fn wake(pipe: RawFd, method: WakeMethod) {
 /// * If it is not possible, the [`O_NONBLOCK`][libc::O_NONBLOCK] will be set on the file
 ///   descriptor and [`write`][libc::write] will be used instead.
 pub fn register_raw(signal: c_int, pipe: RawFd) -> Result<SigId, Error> {
+    #[cfg(not(target_os = "aix"))]
     let res = unsafe { libc::send(pipe, &[] as *const _, 0, libc::MSG_DONTWAIT) };
+    #[cfg(target_os = "aix")]
+    let res = unsafe { libc::send(pipe, &[] as *const _, 0, libc::MSG_NONBLOCK) };
     let fd = match (res, Error::last_os_error().kind()) {
         (0, _) | (-1, ErrorKind::WouldBlock) => WakeFd {
             fd: pipe,

--- a/src/low_level/signal_details.rs
+++ b/src/low_level/signal_details.rs
@@ -112,16 +112,14 @@ fn restore_default(signal: c_int) -> Result<(), Error> {
         // A C structure, supposed to be memset to 0 before use.
         let mut action: libc::sigaction = mem::zeroed();
         #[cfg(target_os = "aix")]
-        let set_action = |action: &mut libc::sigaction, sigaction| {
+        {
             action.sa_union.__su_sigaction = mem::transmute::<
                 usize,
                 extern "C" fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void),
-            >(sigaction)
-        };
+            >(libc::SIG_DFL);
+        }
         #[cfg(not(target_os = "aix"))]
-        let set_action =
-            |action: &mut libc::sigaction, sigaction| action.sa_sigaction = sigaction as _;
-        set_action(&mut action, libc::SIG_DFL);
+        { action.sa_sigaction = libc::SIG_DFL as _; }
         if libc::sigaction(signal, &action, ptr::null_mut()) == 0 {
             Ok(())
         } else {


### PR DESCRIPTION
The main differences for AIX:
- AIX doesn't have `MSG_DONTWAIT`, instead, use `MSG_NONBLOCK` (https://github.com/stephane/libmodbus/issues/294)
- AIX definition for sigaction handler is different: `sa_union { __su_handler: extern fn(c: ::c_int), __su_sigaction: extern fn(c: ::c_int, info: *mut siginfo_t, ptr: *mut ::c_void) }`

Note that AIX hasn't been an official Tier-3 Rust target. (https://github.com/rust-lang/compiler-team/issues/553)