### PR TITLE
Forbid SIGBUS

### DIFF
--- a/signal-hook-registry/src/lib.rs
+++ b/signal-hook-registry/src/lib.rs
@@ -80,9 +80,9 @@ use libc::{c_int, c_void, sigaction, siginfo_t};
 use libc::{c_int, sighandler_t};
 
 #[cfg(not(windows))]
-use libc::{SIGFPE, SIGILL, SIGKILL, SIGSEGV, SIGSTOP};
+use libc::{SIGBUS, SIGFPE, SIGILL, SIGKILL, SIGSEGV, SIGSTOP};
 #[cfg(windows)]
-use libc::{SIGFPE, SIGILL, SIGSEGV};
+use libc::{SIGBUS, SIGFPE, SIGILL, SIGSEGV};
 
 use half_lock::HalfLock;
 
@@ -387,9 +387,9 @@ extern "C" fn handler(sig: c_int, info: *mut siginfo_t, data: *mut c_void) {
 pub const FORBIDDEN: &[c_int] = FORBIDDEN_IMPL;
 
 #[cfg(windows)]
-const FORBIDDEN_IMPL: &[c_int] = &[SIGILL, SIGFPE, SIGSEGV];
+const FORBIDDEN_IMPL: &[c_int] = &[SIGILL, SIGFPE, SIGSEGV, SIGBUS];
 #[cfg(not(windows))]
-const FORBIDDEN_IMPL: &[c_int] = &[SIGKILL, SIGSTOP, SIGILL, SIGFPE, SIGSEGV];
+const FORBIDDEN_IMPL: &[c_int] = &[SIGKILL, SIGSTOP, SIGILL, SIGFPE, SIGSEGV, SIGBUS];
 
 /// Registers an arbitrary action for the given signal.
 ///
@@ -412,6 +412,7 @@ const FORBIDDEN_IMPL: &[c_int] = &[SIGKILL, SIGSTOP, SIGILL, SIGFPE, SIGSEGV];
 /// * `SIGILL`
 /// * `SIGFPE`
 /// * `SIGSEGV`
+/// * `SIGBUS`
 ///
 /// The first two are not possible to override (and the underlying C functions simply ignore all
 /// requests to do so, which smells of possible bugs, or return errors). The rest can be set, but


### PR DESCRIPTION
SIGBUS is similar to SIGSEGV in regards to when it is raised and the sort of special handling required for recovery.

I'm planning (haven't started) a `pagefault` crate specifically designed for handling SIGSEGV and SIGBUS, and want to avoid stepping on each other's toes.