### PR TITLE
QNX Neutrino support

### DIFF
--- a/signal-hook-registry/src/lib.rs
+++ b/signal-hook-registry/src/lib.rs
@@ -165,6 +165,10 @@ impl Slot {
         // Android is broken and uses different int types than the rest (and different depending on
         // the pointer width). This converts the flags to the proper type no matter what it is on
         // the given platform.
+        #[cfg(target_os = "nto")]
+        let flags = 0;
+        // SA_RESTART is supported by qnx https://www.qnx.com/support/knowledgebase.html?id=50130000000SmiD 
+        #[cfg(not(target_os = "nto"))]
         let flags = libc::SA_RESTART;
         #[allow(unused_assignments)]
         let mut siginfo = flags;


### PR DESCRIPTION
This adds support for QNX Neutrino operating system

This would help us with https://github.com/tokio-rs/tokio/pull/6421 and https://github.com/eclipse/kuksa.val/issues/741 so merging this would be appreciated

@AkhilTThomas fyi