### PR TITLE
Bump libc to 0.2.171 to use sigaction for AIX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,9 +566,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 ]
 
 [dependencies]
-libc = "^0.2"
+libc = "^0.2.171"
 signal-hook-registry = { version = "^1.4", path = "signal-hook-registry" }
 
 [dev-dependencies]

--- a/signal-hook-registry/src/lib.rs
+++ b/signal-hook-registry/src/lib.rs
@@ -158,10 +158,7 @@ impl Slot {
     fn new(signal: libc::c_int) -> Result<Self, Error> {
         // C data structure, expected to be zeroed out.
         let mut new: libc::sigaction = unsafe { mem::zeroed() };
-        #[cfg(not(target_os = "aix"))]
-        { new.sa_sigaction = handler as usize; }
-        #[cfg(target_os = "aix")]
-        { new.sa_union.__su_sigaction = handler; }
+        new.sa_sigaction = handler as usize;
         // Android is broken and uses different int types than the rest (and different depending on
         // the pointer width). This converts the flags to the proper type no matter what it is on
         // the given platform.
@@ -239,10 +236,7 @@ impl Prev {
 
     #[cfg(not(windows))]
     unsafe fn execute(&self, sig: c_int, info: *mut siginfo_t, data: *mut c_void) {
-        #[cfg(not(target_os = "aix"))]
         let fptr = self.info.sa_sigaction;
-        #[cfg(target_os = "aix")]
-        let fptr = self.info.sa_union.__su_sigaction as usize;
         if fptr != 0 && fptr != libc::SIG_DFL && fptr != libc::SIG_IGN {
             // Android is broken and uses different int types than the rest (and different
             // depending on the pointer width). This converts the flags to the proper type no

--- a/src/low_level/signal_details.rs
+++ b/src/low_level/signal_details.rs
@@ -111,15 +111,7 @@ fn restore_default(signal: c_int) -> Result<(), Error> {
     unsafe {
         // A C structure, supposed to be memset to 0 before use.
         let mut action: libc::sigaction = mem::zeroed();
-        #[cfg(target_os = "aix")]
-        {
-            action.sa_union.__su_sigaction = mem::transmute::<
-                usize,
-                extern "C" fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void),
-            >(libc::SIG_DFL);
-        }
-        #[cfg(not(target_os = "aix"))]
-        { action.sa_sigaction = libc::SIG_DFL as _; }
+        action.sa_sigaction = libc::SIG_DFL as _;
         if libc::sigaction(signal, &action, ptr::null_mut()) == 0 {
             Ok(())
         } else {


### PR DESCRIPTION
Change to use `sa_sigaction` instead of `sa_union.__su_sigaction`, now that the `libc` crate 0.2.171 implementation for AIX defines `sa_sigaction` as a direct member of `struct sigaction`, aligning it with implementations on other similar platforms. (https://github.com/rust-lang/libc/pull/4250).