### PR TITLE
minor: Close codeblock in `low_lewel::pipe` docs

### DIFF
--- a/src/low_level/pipe.rs
+++ b/src/low_level/pipe.rs
@@ -73,6 +73,7 @@
 //!     println!("Happily terminating");
 //!     Ok(())
 //! }
+//! ```
 
 use std::io::{Error, ErrorKind};
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};


### PR DESCRIPTION
:wave:

Super minor docs fix here - the codefence for the `pipe` module doc wasn't closed. Rustdoc doesn't seem to care but it can mess up some editors' syntax highlighting. Thanks!