### PR TITLE
Qualify `ptr` to fix Windows build regression

### DIFF
--- a/signal-hook-registry/src/lib.rs
+++ b/signal-hook-registry/src/lib.rs
@@ -297,7 +297,7 @@ struct GlobalData {
     race_fallback: HalfLock<Option<Prev>>,
 }
 
-static GLOBAL_DATA: AtomicPtr<GlobalData> = AtomicPtr::new(ptr::null_mut());
+static GLOBAL_DATA: AtomicPtr<GlobalData> = AtomicPtr::new(core::ptr::null_mut());
 #[allow(deprecated)]
 static GLOBAL_INIT: Once = ONCE_INIT;
 


### PR DESCRIPTION
Fixes #173 

Since `signal-hook-registry` version 1.4.4, `ptr` is used unqualified. This works on Unix-like systems, but as shown in #173, it is not found on Windows. Qualifying it as `core::ptr` works.

This restores the ability to build on Windows.