### PR TITLE
Allow mio 1.1+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,14 +556,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -834,7 +834,7 @@ dependencies = [
  "mio 0.6.23",
  "mio 0.7.14",
  "mio 0.8.11",
- "mio 1.0.3",
+ "mio 1.1.0",
  "mio-uds",
  "serial_test",
  "signal-hook",
@@ -925,7 +925,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.3",
+ "mio 1.1.0",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry 1.4.3",
@@ -1095,6 +1095,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +1125,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/signal-hook-mio/Cargo.toml
+++ b/signal-hook-mio/Cargo.toml
@@ -28,7 +28,7 @@ support-v1_0 = ["mio-1_0"]
 [dependencies]
 libc = "~0.2"
 signal-hook = { version = "~0.3", path = ".." }
-mio-1_0 = { package = "mio", version = "~1.0", features = ["net", "os-ext"], optional = true }
+mio-1_0 = { package = "mio", version = "1.0", features = ["net", "os-ext"], optional = true }
 mio-0_8 = { package = "mio", version = "~0.8", features = ["net", "os-ext"], optional = true }
 mio-0_7 = { package = "mio", version = "~0.7", features = ["os-util", "uds"], optional = true }
 mio-0_6 = { package = "mio", version = "~0.6", optional = true }


### PR DESCRIPTION
With mio being 1.x it's now, in theory at least, stable. So anything less than a major version bump should be compatible.

This PR allows any mio 1.x (right now 1.1) so downstream consumers can keep their dependencies up to date easier.