### PR TITLE
Various small cleanups in signal-hook-registry

### DIFF
--- a/signal-hook-registry/src/lib.rs
+++ b/signal-hook-registry/src/lib.rs
@@ -177,7 +177,7 @@ impl Slot {
         //
         // See #169.
 
-        new.sa_sigaction = handler as usize; // If it doesn't compile on AIX, upgrade the libc dependency
+        new.sa_sigaction = handler as *const () as usize; // If it doesn't compile on AIX, upgrade the libc dependency
 
         #[cfg(target_os = "nto")]
         let flags = 0;


### PR DESCRIPTION
Noticed a few small things while reading the code for my own edification. Each commit is independent but they're all simple enough that I didn't want to bother with separate PRs.