### PR TITLE
Exclude development script from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["signal", "unix", "daemon"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 rust-version = "1.66"
+include.workspace = true
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -34,6 +35,9 @@ members = [
     "signal-hook-async-std",
     "serial_test",
 ]
+
+[workspace.package]
+include = ["CHANGELOG.md", "LICENSE-MIT", "LICENSE-APACHE", "README.md", "build.rs", "src/**/*.rs", "tests/**/*.rs", "examples/**/*.rs"]
 
 [dependencies]
 libc = "^0.2"

--- a/signal-hook-async-std/Cargo.toml
+++ b/signal-hook-async-std/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["signal", "unix", "async-std"]
 license = "MIT OR Apache-2.0"
 
 edition = "2018"
+include.workspace = true
 
 [badges]
 travis-ci = { repository = "vorner/signal-hook" }

--- a/signal-hook-mio/Cargo.toml
+++ b/signal-hook-mio/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 repository = "https://github.com/vorner/signal-hook"
 keywords = ["signal", "unix", "mio"]
 license = "MIT OR Apache-2.0"
+include.workspace = true
 
 edition = "2018"
 rust-version = "1.66"

--- a/signal-hook-registry/Cargo.toml
+++ b/signal-hook-registry/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/vorner/signal-hook"
 keywords = ["signal", "unix", "daemon"]
 license = "MIT OR Apache-2.0"
 rust-version = "1.26"
+include.workspace = true
 
 [badges]
 travis-ci = { repository = "vorner/signal-hook" }

--- a/signal-hook-tokio/Cargo.toml
+++ b/signal-hook-tokio/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 repository = "https://github.com/vorner/signal-hook"
 keywords = ["signal", "unix", "tokio"]
 license = "MIT OR Apache-2.0"
+include.workspace = true
 
 edition = "2018"
 


### PR DESCRIPTION
During a dependency review we noticed that the signal-hook crate includes various development scripts. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from beeing included in the published packages to make sure that everything that's included is an conscious choice.